### PR TITLE
fix: resolve all ruff, ty, and complexipy issues

### DIFF
--- a/asr2clip/asr2clip.py
+++ b/asr2clip/asr2clip.py
@@ -186,8 +186,12 @@ def process_file(
                 pass
 
 
-def main():
-    """Main entry point for asr2clip."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for asr2clip.
+
+    Returns:
+        Configured ArgumentParser instance.
+    """
     parser = argparse.ArgumentParser(
         description="Record audio and transcribe to clipboard using ASR API",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -211,14 +215,9 @@ Setup:
 """,
     )
 
-    # Basic options
     parser.add_argument(
-        "-v",
-        "--version",
-        action="version",
-        version=f"asr2clip {__version__}",
+        "-v", "--version", action="version", version=f"asr2clip {__version__}"
     )
-
     parser.add_argument(
         "-c",
         "--config",
@@ -226,15 +225,12 @@ Setup:
         help="Path to configuration file",
         default=None,
     )
-
     parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
         help="Quiet mode - only output transcription and errors",
     )
-
-    # Input/Output
     parser.add_argument(
         "-i",
         "--input",
@@ -242,7 +238,6 @@ Setup:
         help="Transcribe audio file instead of recording",
         default=None,
     )
-
     parser.add_argument(
         "-o",
         "--output",
@@ -250,53 +245,36 @@ Setup:
         help="Append transcripts to file",
         default=None,
     )
-
-    # Setup commands
     parser.add_argument(
-        "--test",
-        action="store_true",
-        help="Test API configuration and exit",
+        "--test", action="store_true", help="Test API configuration and exit"
     )
-
     parser.add_argument(
-        "--list_devices",
-        action="store_true",
-        help="List available audio input devices",
+        "--list_devices", action="store_true", help="List available audio input devices"
     )
-
     parser.add_argument(
         "--device",
         metavar="DEV",
         help="Audio input device (name or index)",
         default=None,
     )
-
     parser.add_argument(
-        "-e",
-        "--edit",
-        action="store_true",
-        help="Open configuration file in editor",
+        "-e", "--edit", action="store_true", help="Open configuration file in editor"
     )
-
     parser.add_argument(
         "--generate_config",
         action="store_true",
         help="Create config file at ~/.config/asr2clip/config.yaml",
     )
-
     parser.add_argument(
         "--print_config",
         action="store_true",
         help="Print template configuration to stdout",
     )
-
-    # Continuous recording modes
     parser.add_argument(
         "--vad",
         action="store_true",
         help="Continuous recording with voice activity detection",
     )
-
     parser.add_argument(
         "--interval",
         type=float,
@@ -304,27 +282,23 @@ Setup:
         default=None,
         help="Continuous recording with fixed interval (seconds)",
     )
-
     parser.add_argument(
         "--adaptive",
         action="store_true",
         help="Adaptive threshold (default when --vad is used)",
     )
-
     parser.add_argument(
         "--calibrate",
         action="store_true",
         help="Calibrate silence threshold from ambient noise",
     )
-
     parser.add_argument(
         "--silence_threshold",
         type=float,
         metavar="RMS",
-        default=None,  # None means auto (use adaptive)
+        default=None,
         help="Silence threshold (default: auto with adaptive)",
     )
-
     parser.add_argument(
         "--silence_duration",
         type=float,
@@ -332,19 +306,24 @@ Setup:
         default=1.5,
         help="Silence duration to trigger transcription (default: 1.5)",
     )
-
     parser.add_argument(
         "--no_adaptive",
         action="store_true",
         help="Disable adaptive threshold (use fixed threshold)",
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Determine if continuous mode is enabled
-    continuous_mode = args.vad or args.interval is not None
 
-    # Validate option combinations
+def _validate_args(args: argparse.Namespace):
+    """Validate and resolve argument defaults.
+
+    Args:
+        args: Parsed arguments namespace (modified in-place).
+
+    Raises:
+        SystemExit: On invalid argument combinations.
+    """
     if args.adaptive and not args.vad:
         print("Error: --adaptive requires --vad")
         sys.exit(1)
@@ -357,13 +336,18 @@ Setup:
     if args.vad and not args.no_adaptive and args.silence_threshold is None:
         args.adaptive = True
 
-    # Set default threshold if not specified
     if args.silence_threshold is None:
         args.silence_threshold = 0.01
 
-    # Set default interval for continuous mode
     if args.interval is None:
         args.interval = 30.0
+
+
+def main():
+    """Main entry point for asr2clip."""
+    parser = _build_parser()
+    args = parser.parse_args()
+    _validate_args(args)
 
     # Handle --generate_config and --print_config
     if args.print_config:
@@ -374,12 +358,10 @@ Setup:
         generate_config()
         return
 
-    # Handle --edit
     if args.edit:
         open_in_editor(args.config)
         return
 
-    # Handle --list_devices
     if args.list_devices:
         list_audio_devices()
         return
@@ -392,15 +374,12 @@ Setup:
     setup_logging(verbose=not quiet)
     set_verbose(not quiet)
 
-    # Handle --test
     if args.test:
         success = test_config(config)
         sys.exit(0 if success else 1)
 
-    # Get audio device
     device = get_audio_device(config, args.device)
 
-    # Handle --calibrate
     if args.calibrate:
         from .vad import calibrate_silence_threshold
 
@@ -408,10 +387,8 @@ Setup:
         print(f"\nUse this threshold with: --silence_threshold {threshold:.4f}")
         return
 
-    # Handle continuous recording mode (--vad or --interval)
-    if continuous_mode:
+    if args.vad or args.interval is not None:
         api_key, api_base_url, model_name, org_id = get_api_config(config)
-
         continuous_recording(
             api_key=api_key,
             api_base_url=api_base_url,
@@ -427,12 +404,10 @@ Setup:
         )
         return
 
-    # Handle --input (file transcription)
     if args.input:
         process_file(config, args.input, args.output)
         return
 
-    # Default: record and transcribe
     process_recording(config, device, args.output)
 
 

--- a/asr2clip/audio.py
+++ b/asr2clip/audio.py
@@ -3,7 +3,7 @@
 import io
 import tempfile
 import wave
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import sounddevice as sd
@@ -136,7 +136,7 @@ def save_audio(audio_data: np.ndarray, sample_rate: int = 16000) -> str:
     return temp_file.name
 
 
-def convert_audio_to_wav(input_path: str, output_path: str = None) -> str:
+def convert_audio_to_wav(input_path: str, output_path: str | None = None) -> str:
     """Convert an audio file to WAV format.
 
     Args:

--- a/asr2clip/config.py
+++ b/asr2clip/config.py
@@ -48,7 +48,7 @@ model_name: "whisper-1"                     # or other compatible model
 """
 
 
-def find_config_path(config_file: str = None) -> str | None:
+def find_config_path(config_file: str | None = None) -> str | None:
     """Find the configuration file path.
 
     Args:
@@ -93,7 +93,7 @@ def read_config(config_file: str) -> dict:
         sys.exit(1)
 
     try:
-        with open(config_path, "r") as file:
+        with open(config_path) as file:
             config = yaml.safe_load(file)
             # Handle legacy config format
             if "asr_model" in config and len(config) == 1:
@@ -104,7 +104,7 @@ def read_config(config_file: str) -> dict:
         sys.exit(1)
 
 
-def open_in_editor(config_file: str = None):
+def open_in_editor(config_file: str | None = None):
     """Open the configuration file in the system's default editor.
 
     Args:
@@ -151,7 +151,7 @@ def open_in_editor(config_file: str = None):
 
 
 def generate_config(
-    output_path: str = None, force: bool = False, print_only: bool = False
+    output_path: str | None = None, force: bool = False, print_only: bool = False
 ) -> str | None:
     """Generate a template configuration file.
 
@@ -210,7 +210,7 @@ def get_api_config(config: dict) -> tuple[str, str, str, str | None]:
     return api_key, api_base_url, model_name, org_id
 
 
-def get_audio_device(config: dict, cli_device: str = None) -> str | int | None:
+def get_audio_device(config: dict, cli_device: str | None = None) -> str | int | None:
     """Get audio device from config or CLI argument.
 
     Args:

--- a/asr2clip/daemon.py
+++ b/asr2clip/daemon.py
@@ -5,7 +5,7 @@ import queue
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 
@@ -32,6 +32,298 @@ class TranscriptionTask:
     audio_path: str
     duration: float
     timestamp: float
+
+
+@dataclass
+class RecorderConfig:
+    """Configuration for the continuous recorder."""
+
+    api_key: str
+    api_base_url: str
+    model_name: str
+    org_id: str | None = None
+    device: str | int | None = None
+    interval: float = 30.0
+    output_file: str | None = None
+    sample_rate: int = 16000
+    vad_enabled: bool = False
+    silence_threshold: float = 0.01
+    silence_duration: float = 1.5
+    adaptive_threshold: bool = False
+    min_transcribe_interval: float = 0.5
+    max_concurrent_transcriptions: int = 3
+
+
+@dataclass
+class RecorderState:
+    """Mutable state for the continuous recorder."""
+
+    audio_chunks: list = field(default_factory=list)
+    chunks_lock: threading.Lock = field(default_factory=threading.Lock)
+    last_transcribe_time: float = field(default_factory=time.time)
+    task_sequence: int = 0
+    task_sequence_lock: threading.Lock = field(default_factory=threading.Lock)
+    result_queue: queue.PriorityQueue = field(default_factory=queue.PriorityQueue)
+    next_output_sequence: int = 0
+    next_output_lock: threading.Lock = field(default_factory=threading.Lock)
+    pending_tasks: dict = field(default_factory=dict)
+    should_transcribe: threading.Event = field(default_factory=threading.Event)
+    vad: VoiceActivityDetector | None = None
+
+
+def _calibrate_threshold(cfg: RecorderConfig) -> float:
+    """Calibrate silence threshold from ambient noise.
+
+    Args:
+        cfg: Recorder configuration.
+
+    Returns:
+        Calibrated silence threshold.
+    """
+    info("Calibrating ambient noise level...")
+    calibrated = calibrate_silence_threshold(
+        device=cfg.device, duration=1.0, sample_rate=cfg.sample_rate
+    )
+    return max(calibrated, 0.001)
+
+
+def _log_startup(cfg: RecorderConfig):
+    """Log startup information.
+
+    Args:
+        cfg: Recorder configuration.
+    """
+    if cfg.vad_enabled:
+        info(
+            f"Starting continuous recording with VAD (silence: {cfg.silence_duration}s)"
+        )
+        if cfg.adaptive_threshold:
+            info(f"Adaptive threshold enabled (base: {cfg.silence_threshold:.4f})")
+        else:
+            info(f"Silence threshold: {cfg.silence_threshold:.4f}")
+    else:
+        info(f"Starting continuous recording mode (interval: {cfg.interval}s)")
+    info("Press Ctrl+C to stop")
+    print_separator()
+
+
+def _make_audio_callback(state: RecorderState):
+    """Create the audio input stream callback.
+
+    Args:
+        state: Recorder state.
+
+    Returns:
+        Callback function for sounddevice.InputStream.
+    """
+
+    def audio_callback(indata, frames, time_info, status):
+        if status:
+            warning(f"Audio status: {status}")
+        with state.chunks_lock:
+            state.audio_chunks.append(indata.copy())
+        if state.vad is not None and state.vad.process_chunk(indata):
+            state.should_transcribe.set()
+
+    return audio_callback
+
+
+def _process_transcription(
+    task: TranscriptionTask,
+    cfg: RecorderConfig,
+) -> tuple[int, str | None, str | None]:
+    """Process a transcription task.
+
+    Args:
+        task: The transcription task to process.
+        cfg: Recorder configuration.
+
+    Returns:
+        Tuple of (sequence, text, error_message).
+    """
+    try:
+        text = transcribe_audio(
+            task.audio_path,
+            cfg.api_key,
+            cfg.api_base_url,
+            cfg.model_name,
+            cfg.org_id,
+            raise_on_error=True,
+        )
+        return (task.sequence, text, None)
+    except TranscriptionError as e:
+        return (task.sequence, None, str(e))
+    finally:
+        try:
+            os.unlink(task.audio_path)
+        except Exception:
+            pass
+
+
+def _run_output_worker(state: RecorderState, output_file: str | None):
+    """Output transcription results in order.
+
+    Args:
+        state: Recorder state.
+        output_file: Optional file to append transcripts to.
+    """
+    while not is_stop_requested():
+        try:
+            sequence, text, error = state.result_queue.get(timeout=0.1)
+        except queue.Empty:
+            continue
+
+        with state.next_output_lock:
+            while sequence != state.next_output_sequence and not is_stop_requested():
+                time.sleep(0.01)
+
+            if is_stop_requested():
+                break
+
+            _output_single_result(text, error, output_file)
+            state.next_output_sequence += 1
+
+
+def _output_single_result(text: str | None, error: str | None, output_file: str | None):
+    """Output a single transcription result.
+
+    Args:
+        text: Transcribed text (if successful).
+        error: Error message (if failed).
+        output_file: Optional file to append transcripts to.
+    """
+    if error:
+        print(f"\r{RED}✗{RESET} Failed: {error}" + " " * 20, flush=True)
+    elif text and text.strip():
+        print(f"\r{GREEN}✓{RESET} Transcribed" + " " * 30, flush=True)
+        output_transcript(text, to_clipboard=True, to_stdout=True, to_file=output_file)
+    else:
+        print(f"\r{YELLOW}○{RESET} (no speech)" + " " * 30, flush=True)
+
+
+def _transcribe_chunks(
+    cfg: RecorderConfig,
+    state: RecorderState,
+    executor: ThreadPoolExecutor,
+    skip_silence_check: bool = False,
+):
+    """Transcribe accumulated audio chunks asynchronously.
+
+    Args:
+        cfg: Recorder configuration.
+        state: Recorder state.
+        executor: Thread pool executor for async transcription.
+        skip_silence_check: If True, skip the silence check.
+    """
+    if time.time() - state.last_transcribe_time < cfg.min_transcribe_interval:
+        return
+
+    with state.chunks_lock:
+        if not state.audio_chunks:
+            return
+        audio_data = np.concatenate(state.audio_chunks, axis=0)
+        state.audio_chunks = []
+
+    if state.vad is not None:
+        state.vad.reset()
+
+    duration = get_audio_duration(audio_data, cfg.sample_rate)
+    if duration < 0.5:
+        return
+
+    if not skip_silence_check:
+        rms = calculate_rms(audio_data)
+        threshold = (
+            state.vad.get_current_threshold() if state.vad else cfg.silence_threshold
+        )
+        if rms < threshold:
+            state.last_transcribe_time = time.time()
+            return
+
+    temp_path = save_audio(audio_data, cfg.sample_rate)
+
+    with state.task_sequence_lock:
+        seq = state.task_sequence
+        state.task_sequence += 1
+
+    print(
+        f"\n{CYAN}●{RESET} Recording {duration:.1f}s → {YELLOW}⟳{RESET} Sending #{seq}...",
+        end="",
+        flush=True,
+    )
+
+    task = TranscriptionTask(
+        sequence=seq, audio_path=temp_path, duration=duration, timestamp=time.time()
+    )
+
+    def task_callback(future):
+        try:
+            result = future.result()
+            state.result_queue.put(result)
+        except Exception as e:
+            state.result_queue.put((task.sequence, None, str(e)))
+        finally:
+            with state.task_sequence_lock:
+                state.pending_tasks.pop(task.sequence, None)
+
+    future = executor.submit(_process_transcription, task, cfg)
+    future.add_done_callback(task_callback)
+
+    with state.task_sequence_lock:
+        state.pending_tasks[seq] = future
+
+    state.last_transcribe_time = time.time()
+
+
+def _run_recording_loop(cfg: RecorderConfig, state: RecorderState, executor):
+    """Run the main recording loop.
+
+    Args:
+        cfg: Recorder configuration.
+        state: Recorder state.
+        executor: Thread pool executor.
+    """
+    import sounddevice as sd
+
+    audio_callback = _make_audio_callback(state)
+
+    try:
+        with sd.InputStream(
+            samplerate=cfg.sample_rate,
+            channels=1,
+            dtype="float32",
+            device=cfg.device,
+            callback=audio_callback,
+        ):
+            while not is_stop_requested():
+                if cfg.vad_enabled:
+                    _handle_vad_iteration(cfg, state, executor)
+                else:
+                    sd.sleep(100)
+                    if time.time() - state.last_transcribe_time >= cfg.interval:
+                        _transcribe_chunks(
+                            cfg, state, executor, skip_silence_check=False
+                        )
+    except KeyboardInterrupt:
+        pass
+
+
+def _handle_vad_iteration(
+    cfg: RecorderConfig, state: RecorderState, executor: ThreadPoolExecutor
+):
+    """Handle a single VAD-mode iteration.
+
+    Args:
+        cfg: Recorder configuration.
+        state: Recorder state.
+        executor: Thread pool executor.
+    """
+    triggered = state.should_transcribe.wait(timeout=0.1)
+    if triggered:
+        state.should_transcribe.clear()
+        _transcribe_chunks(cfg, state, executor, skip_silence_check=True)
+    elif time.time() - state.last_transcribe_time >= cfg.interval:
+        _transcribe_chunks(cfg, state, executor, skip_silence_check=False)
 
 
 def continuous_recording(
@@ -72,262 +364,57 @@ def continuous_recording(
         min_transcribe_interval: Minimum interval between transcription triggers (seconds).
         max_concurrent_transcriptions: Maximum number of concurrent transcription requests.
     """
-    import sounddevice as sd
-
     setup_signal_handlers(daemon_mode=True)
 
-    # Auto-calibrate threshold if adaptive mode is enabled and no manual threshold set
+    cfg = RecorderConfig(
+        api_key=api_key,
+        api_base_url=api_base_url,
+        model_name=model_name,
+        org_id=org_id,
+        device=device,
+        interval=interval,
+        output_file=output_file,
+        sample_rate=sample_rate,
+        vad_enabled=vad_enabled,
+        silence_threshold=silence_threshold,
+        silence_duration=silence_duration,
+        adaptive_threshold=adaptive_threshold,
+        min_transcribe_interval=min_transcribe_interval,
+        max_concurrent_transcriptions=max_concurrent_transcriptions,
+    )
+
     if vad_enabled and adaptive_threshold and silence_threshold == 0.01:
-        info("Calibrating ambient noise level...")
-        calibrated = calibrate_silence_threshold(
-            device=device, duration=1.0, sample_rate=sample_rate
-        )
-        # Use calibrated threshold, but ensure minimum sensitivity
-        silence_threshold = max(calibrated, 0.001)
+        cfg.silence_threshold = _calibrate_threshold(cfg)
 
+    _log_startup(cfg)
+
+    state = RecorderState()
     if vad_enabled:
-        info(f"Starting continuous recording with VAD (silence: {silence_duration}s)")
-        if adaptive_threshold:
-            info(f"Adaptive threshold enabled (base: {silence_threshold:.4f})")
-        else:
-            info(f"Silence threshold: {silence_threshold:.4f}")
-    else:
-        info(f"Starting continuous recording mode (interval: {interval}s)")
-    info("Press Ctrl+C to stop")
-    print_separator()
-
-    audio_chunks = []
-    chunks_lock = threading.Lock()
-    last_transcribe_time = time.time()
-
-    # Initialize VAD if enabled
-    vad = None
-    if vad_enabled:
-        vad = VoiceActivityDetector(
+        state.vad = VoiceActivityDetector(
             sample_rate=sample_rate,
-            silence_threshold=silence_threshold,
+            silence_threshold=cfg.silence_threshold,
             silence_duration=silence_duration,
             adaptive=adaptive_threshold,
         )
 
-    should_transcribe = threading.Event()
-
-    # Async transcription setup
-    task_sequence = 0
-    task_sequence_lock = threading.Lock()
-    result_queue = queue.PriorityQueue()  # (sequence, result)
-    next_output_sequence = 0
-    next_output_lock = threading.Lock()
     executor = ThreadPoolExecutor(max_workers=max_concurrent_transcriptions)
-    pending_tasks = {}  # sequence -> Future
 
-    def audio_callback(indata, frames, time_info, status):
-        if status:
-            warning(f"Audio status: {status}")
-        with chunks_lock:
-            audio_chunks.append(indata.copy())
-
-        # Check VAD if enabled
-        if vad is not None:
-            if vad.process_chunk(indata):
-                should_transcribe.set()
-
-    def process_transcription(
-        task: TranscriptionTask,
-    ) -> tuple[int, str | None, str | None]:
-        """Process a transcription task asynchronously.
-
-        Args:
-            task: The transcription task to process.
-
-        Returns:
-            Tuple of (sequence, text, error_message).
-        """
-        try:
-            text = transcribe_audio(
-                task.audio_path,
-                api_key,
-                api_base_url,
-                model_name,
-                org_id,
-                raise_on_error=True,
-            )
-            return (task.sequence, text, None)
-        except TranscriptionError as e:
-            return (task.sequence, None, str(e))
-        finally:
-            # Clean up temp file
-            try:
-                os.unlink(task.audio_path)
-            except Exception:
-                pass
-
-    def output_worker():
-        """Worker thread to output results in order."""
-        nonlocal next_output_sequence
-
-        while not is_stop_requested():
-            try:
-                # Wait for next result with timeout
-                sequence, text, error = result_queue.get(timeout=0.1)
-
-                # Wait until it's this sequence's turn
-                with next_output_lock:
-                    while sequence != next_output_sequence and not is_stop_requested():
-                        time.sleep(0.01)
-
-                    if is_stop_requested():
-                        break
-
-                    # Output the result
-                    if error:
-                        print(f"\r{RED}✗{RESET} Failed: {error}" + " " * 20, flush=True)
-                    elif text and text.strip():
-                        print(f"\r{GREEN}✓{RESET} Transcribed" + " " * 30, flush=True)
-                        output_transcript(
-                            text,
-                            to_clipboard=True,
-                            to_stdout=True,
-                            to_file=output_file,
-                        )
-                    else:
-                        print(f"\r{YELLOW}○{RESET} (no speech)" + " " * 30, flush=True)
-
-                    next_output_sequence += 1
-
-            except queue.Empty:
-                continue
-
-    def transcribe_chunks(reason: str = "interval", skip_silence_check: bool = False):
-        """Transcribe accumulated audio chunks asynchronously.
-
-        Args:
-            reason: Reason for transcription (for logging).
-            skip_silence_check: If True, skip the silence check (used when VAD triggered).
-        """
-        nonlocal audio_chunks, last_transcribe_time, task_sequence
-
-        # Check minimum interval
-        if time.time() - last_transcribe_time < min_transcribe_interval:
-            return
-
-        with chunks_lock:
-            if not audio_chunks:
-                return
-            audio_data = np.concatenate(audio_chunks, axis=0)
-            audio_chunks = []
-
-        # Reset VAD state
-        if vad is not None:
-            vad.reset()
-
-        duration = get_audio_duration(audio_data, sample_rate)
-        if duration < 0.5:
-            return  # Too short, skip silently
-
-        # Check if audio has any sound (skip silent recordings)
-        # But skip this check if VAD already confirmed speech
-        if not skip_silence_check:
-            rms = calculate_rms(audio_data)
-            current_threshold = (
-                vad.get_current_threshold() if vad else silence_threshold
-            )
-            if rms < current_threshold:
-                # Silent, skip without verbose logging
-                last_transcribe_time = time.time()
-                return
-
-        # Save to temp file
-        temp_path = save_audio(audio_data, sample_rate)
-
-        # Get sequence number
-        with task_sequence_lock:
-            seq = task_sequence
-            task_sequence += 1
-
-        # Show recording complete indicator (with newline to avoid overlap)
-        print(
-            f"\n{CYAN}●{RESET} Recording {duration:.1f}s → {YELLOW}⟳{RESET} Sending #{seq}...",
-            end="",
-            flush=True,
-        )
-
-        # Create task and submit
-        task = TranscriptionTask(
-            sequence=seq,
-            audio_path=temp_path,
-            duration=duration,
-            timestamp=time.time(),
-        )
-
-        def task_callback(future):
-            """Callback when transcription completes."""
-            try:
-                result = future.result()
-                result_queue.put(result)
-            except Exception as e:
-                result_queue.put((task.sequence, None, str(e)))
-            finally:
-                # Remove from pending tasks
-                with task_sequence_lock:
-                    pending_tasks.pop(task.sequence, None)
-
-        future = executor.submit(process_transcription, task)
-        future.add_done_callback(task_callback)
-
-        with task_sequence_lock:
-            pending_tasks[seq] = future
-
-        last_transcribe_time = time.time()
-
-    # Start output worker thread
-    output_thread = threading.Thread(target=output_worker, daemon=True)
+    output_thread = threading.Thread(
+        target=_run_output_worker, args=(state, output_file), daemon=True
+    )
     output_thread.start()
 
-    try:
-        with sd.InputStream(
-            samplerate=sample_rate,
-            channels=1,
-            dtype="float32",
-            device=device,
-            callback=audio_callback,
-        ):
-            while not is_stop_requested():
-                # Wait for either VAD trigger or timeout
-                if vad_enabled:
-                    triggered = should_transcribe.wait(timeout=0.1)
-                    if triggered:
-                        should_transcribe.clear()
-                        # VAD confirmed speech, skip silence check
-                        transcribe_chunks(
-                            reason="speech detected", skip_silence_check=True
-                        )
-                    # Also check max interval (but check for silence)
-                    elif time.time() - last_transcribe_time >= interval:
-                        transcribe_chunks(
-                            reason="max interval", skip_silence_check=False
-                        )
-                else:
-                    sd.sleep(100)
-                    # Check if it's time to transcribe
-                    if time.time() - last_transcribe_time >= interval:
-                        transcribe_chunks(reason="interval", skip_silence_check=False)
+    _run_recording_loop(cfg, state, executor)
 
-    except KeyboardInterrupt:
-        pass
-
-    # Transcribe any remaining audio
     log("\nProcessing remaining audio...")
-    transcribe_chunks(reason="final", skip_silence_check=False)
+    _transcribe_chunks(cfg, state, executor, skip_silence_check=False)
 
-    # Wait for all pending tasks to complete
-    if pending_tasks:
+    if state.pending_tasks:
         log("Waiting for pending transcriptions...")
         executor.shutdown(wait=True, cancel_futures=False)
     else:
         executor.shutdown(wait=False, cancel_futures=True)
 
-    # Wait for output worker to finish
     if output_thread.is_alive():
         output_thread.join(timeout=2.0)
 

--- a/asr2clip/logging.py
+++ b/asr2clip/logging.py
@@ -7,7 +7,6 @@ with ANSI color codes for terminal output.
 import logging
 import os
 import sys
-from typing import Optional
 
 
 # ANSI color codes for terminal output
@@ -135,7 +134,7 @@ class ColoredFormatter(logging.Formatter):
         logging.CRITICAL: "CRIT",
     }
 
-    def __init__(self, fmt: Optional[str] = None, datefmt: Optional[str] = None):
+    def __init__(self, fmt: str | None = None, datefmt: str | None = None):
         """Initialize the formatter.
 
         Args:
@@ -183,14 +182,14 @@ class ColoredFormatter(logging.Formatter):
 
 
 # Module-level logger
-_logger: Optional[logging.Logger] = None
+_logger: logging.Logger | None = None
 _verbose: bool = True
 
 
 def setup_logging(
     verbose: bool = True,
     debug: bool = False,
-    log_file: Optional[str] = None,
+    log_file: str | None = None,
 ) -> logging.Logger:
     """Set up the logging system.
 

--- a/asr2clip/transcribe.py
+++ b/asr2clip/transcribe.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import time
+from typing import NoReturn
 
 import httpx
 
@@ -19,6 +20,66 @@ class TranscriptionError(Exception):
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_DELAY = 2.0  # seconds
 DEFAULT_TIMEOUT = 60.0  # seconds
+
+
+def _handle_transcription_failure(
+    error_msg: str,
+    raise_on_error: bool,
+    cause: Exception | None = None,
+) -> NoReturn:
+    """Handle a transcription failure by raising or exiting.
+
+    Args:
+        error_msg: The error message.
+        raise_on_error: If True, raise TranscriptionError.
+        cause: Optional original exception.
+
+    Raises:
+        TranscriptionError: If raise_on_error is True.
+        SystemExit: If raise_on_error is False.
+    """
+    if raise_on_error:
+        raise TranscriptionError(error_msg) from cause
+    error(error_msg)
+    sys.exit(1)
+
+
+def _attempt_transcription(
+    audio_file_path: str,
+    url: str,
+    headers: dict,
+    model_name: str,
+    timeout: float,
+) -> str:
+    """Make a single transcription API request.
+
+    Args:
+        audio_file_path: Path to the audio file.
+        url: API endpoint URL.
+        headers: Request headers.
+        model_name: Model name.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Transcribed text.
+
+    Raises:
+        httpx.TimeoutException: On request timeout.
+        httpx.RequestError: On request failure.
+        TranscriptionError: On API error response.
+    """
+    with open(audio_file_path, "rb") as audio_file:
+        files = {"file": (os.path.basename(audio_file_path), audio_file, "audio/wav")}
+        data = {"model": model_name}
+
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(url, headers=headers, files=files, data=data)
+
+    if response.status_code != 200:
+        raise TranscriptionError(f"API error {response.status_code}: {response.text}")
+
+    result = response.json()
+    return result.get("text", "")
 
 
 def transcribe_audio(
@@ -66,47 +127,11 @@ def transcribe_audio(
 
     for attempt in range(max_retries + 1):
         try:
-            with open(audio_file_path, "rb") as audio_file:
-                files = {
-                    "file": (os.path.basename(audio_file_path), audio_file, "audio/wav")
-                }
-                data = {"model": model_name}
-
-                # Logging is now handled by daemon.py with colored indicators
-                pass
-
-                with httpx.Client(timeout=timeout) as client:
-                    response = client.post(url, headers=headers, files=files, data=data)
-
-                if response.status_code != 200:
-                    error_msg = f"API error {response.status_code}: {response.text}"
-                    if raise_on_error:
-                        raise TranscriptionError(error_msg)
-                    error(error_msg)
-                    sys.exit(1)
-
-                result = response.json()
-                return result.get("text", "")
-
-        except httpx.TimeoutException as e:
+            return _attempt_transcription(
+                audio_file_path, url, headers, model_name, timeout
+            )
+        except (httpx.TimeoutException, httpx.RequestError) as e:
             last_error = e
-            if attempt < max_retries:
-                warning(
-                    f"Request timed out (attempt {attempt + 1}/{max_retries + 1}). "
-                    f"Retrying in {retry_delay}s..."
-                )
-                time.sleep(retry_delay)
-                continue
-            else:
-                error_msg = f"Request timed out after {max_retries + 1} attempts."
-                if raise_on_error:
-                    raise TranscriptionError(error_msg) from last_error
-                error(error_msg)
-                sys.exit(1)
-
-        except httpx.RequestError as e:
-            last_error = e
-            # Retry on connection errors as well
             if attempt < max_retries:
                 warning(
                     f"Request failed (attempt {attempt + 1}/{max_retries + 1}): {e}. "
@@ -114,26 +139,18 @@ def transcribe_audio(
                 )
                 time.sleep(retry_delay)
                 continue
-            else:
-                error_msg = f"Request failed after {max_retries + 1} attempts: {e}"
-                if raise_on_error:
-                    raise TranscriptionError(error_msg) from last_error
-                error(error_msg)
-                sys.exit(1)
-
+            error_msg = f"Request failed after {max_retries + 1} attempts: {e}"
+            _handle_transcription_failure(error_msg, raise_on_error, last_error)
+        except TranscriptionError as e:
+            _handle_transcription_failure(str(e), raise_on_error, e)
         except Exception as e:
-            error_msg = f"Transcription error: {e}"
-            if raise_on_error:
-                raise TranscriptionError(error_msg) from e
-            error(error_msg)
-            sys.exit(1)
+            _handle_transcription_failure(
+                f"Transcription error: {e}", raise_on_error, e
+            )
 
-    # Should not reach here, but just in case
-    error_msg = "Unexpected error in transcription retry loop"
-    if raise_on_error:
-        raise TranscriptionError(error_msg)
-    error(error_msg)
-    sys.exit(1)
+    _handle_transcription_failure(
+        "Unexpected error in transcription retry loop", raise_on_error
+    )
 
 
 def test_transcription(


### PR DESCRIPTION
## Summary
- Fix 5 `ty` type annotation errors (`str = None` → `str | None = None`)
- Fix 7 `ruff` auto-fixable issues (UP035, UP015, UP045) + 1 C901 complexity violation
- Fix 3 `complexipy` failures by refactoring complex functions:
  - `main` (18→10): extract `_build_parser()` and `_validate_args()`
  - `transcribe_audio` (35→9): extract `_attempt_transcription()` and `_handle_transcription_failure()`
  - `continuous_recording` (80→6): decompose into `RecorderConfig`/`RecorderState` dataclasses and modular helper functions

## Test plan
- [x] `ruff check asr2clip/` passes with 0 errors
- [x] `ty check` passes with 0 diagnostics
- [x] `complexipy asr2clip/` passes all functions within max-complexity-allowed=15
- [ ] Manual smoke test: `asr2clip --test`, `asr2clip --vad`