### PR TITLE
ci: add lint and type check workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint & Type Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Ruff check
+        run: ruff check asr2clip/
+
+      - name: Ruff format check
+        run: ruff format --check asr2clip/
+
+      - name: Type check (ty)
+        run: ty check
+
+      - name: Complexity check (complexipy)
+        run: complexipy asr2clip/


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for code quality checks
- Runs on push to master and all PRs targeting master
- Python 3.10 + 3.12 matrix
- Checks: `ruff check`, `ruff format --check`, `ty check`, `complexipy`

## Test plan
- [ ] CI passes on this PR itself