### PR TITLE
feat: add local ASR server with OpenAI-compatible API

### DIFF
--- a/asr2clip/asr2clip.py
+++ b/asr2clip/asr2clip.py
@@ -212,6 +212,11 @@ Setup:
   asr2clip --test                  # Test API connection
   asr2clip --list_devices          # List audio devices
   asr2clip --calibrate             # Calibrate silence threshold
+
+Local ASR server:
+  asr2clip --serve                 # Start local ASR server on :8000
+  asr2clip --serve --port 9000     # Start on custom port
+  asr2clip --download-model        # Download SenseVoice model
 """,
     )
 
@@ -312,6 +317,41 @@ Setup:
         help="Disable adaptive threshold (use fixed threshold)",
     )
 
+    # Local ASR server
+    server_group = parser.add_argument_group("Local ASR server")
+    server_group.add_argument(
+        "--serve",
+        action="store_true",
+        help="Start the local ASR API server",
+    )
+    server_group.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Server bind address (default: 127.0.0.1)",
+    )
+    server_group.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Server bind port (default: 8000)",
+    )
+    server_group.add_argument(
+        "--model-dir",
+        default=None,
+        help="Path to ASR model directory",
+    )
+    server_group.add_argument(
+        "--num-threads",
+        type=int,
+        default=4,
+        help="Inference threads (default: 4)",
+    )
+    server_group.add_argument(
+        "--download-model",
+        action="store_true",
+        help="Download the SenseVoice model and exit",
+    )
+
     return parser
 
 
@@ -347,6 +387,33 @@ def main():
     """Main entry point for asr2clip."""
     parser = _build_parser()
     args = parser.parse_args()
+
+    # Handle --serve (local ASR server) — before validation
+    if args.serve:
+        from .local_asr import check_deps
+
+        check_deps()
+        from .local_asr.app import run_server
+
+        run_server(
+            host=args.host,
+            port=args.port,
+            model_dir=args.model_dir,
+            num_threads=args.num_threads,
+        )
+        return
+
+    # Handle --download-model — before validation
+    if args.download_model:
+        from .local_asr import check_deps
+
+        check_deps()
+        from .local_asr.model_manager import download_model, resolve_model_dir
+
+        model_dir = resolve_model_dir(args.model_dir)
+        download_model(model_dir)
+        return
+
     _validate_args(args)
 
     # Handle --generate_config and --print_config

--- a/asr2clip/local_asr/__init__.py
+++ b/asr2clip/local_asr/__init__.py
@@ -1,0 +1,31 @@
+"""Local ASR server providing an OpenAI-compatible transcription API."""
+
+_INSTALL_HINT = (
+    "Local ASR server dependencies are not installed. "
+    "Install them with: pip install asr2clip[local_asr]"
+)
+
+
+def check_deps() -> None:
+    """Verify that server dependencies are available.
+
+    Raises:
+        ImportError: If any required dependency is missing.
+    """
+    missing = []
+    for pkg in ("fastapi", "uvicorn", "sherpa_onnx"):
+        try:
+            __import__(pkg)
+        except ImportError:
+            missing.append(pkg)
+
+    if missing:
+        raise ImportError(f"{_INSTALL_HINT}\n  Missing: {', '.join(missing)}")
+
+
+def cli_main() -> None:
+    """Entry point for the ``asr2clip-serve`` console script."""
+    check_deps()
+    from .app import run_server_cli
+
+    run_server_cli()

--- a/asr2clip/local_asr/app.py
+++ b/asr2clip/local_asr/app.py
@@ -1,0 +1,250 @@
+"""FastAPI application providing an OpenAI-compatible ASR endpoint."""
+
+import argparse
+import logging
+import time
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, File, Form, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+from .engine import ASREngine
+from .model_manager import (
+    download_model,
+    get_model_paths,
+    resolve_model_dir,
+    validate_model,
+)
+
+logger = logging.getLogger("asr2clip.local_asr")
+
+# Module-level state set during lifespan
+_engine: ASREngine | None = None
+_model_name: str = "sensevoice-small"
+
+# Configuration passed via module-level setter before app starts
+_config: dict = {}
+
+
+def configure(
+    model_dir: str | None = None,
+    num_threads: int = 4,
+) -> None:
+    """Set server configuration before startup.
+
+    Args:
+        model_dir: Path to model directory (None for auto-detection).
+        num_threads: Number of inference threads.
+    """
+    _config["model_dir"] = model_dir
+    _config["num_threads"] = num_threads
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Initialize the ASR engine on startup."""
+    global _engine
+
+    model_dir = resolve_model_dir(_config.get("model_dir"))
+    num_threads = _config.get("num_threads", 4)
+
+    if not validate_model(model_dir):
+        logger.info("Model not found at %s, downloading...", model_dir)
+        download_model(model_dir)
+
+    model_path, tokens_path = get_model_paths(model_dir)
+    logger.info("Loading model from %s", model_dir)
+
+    t0 = time.perf_counter()
+    _engine = ASREngine(
+        model_path=str(model_path),
+        tokens_path=str(tokens_path),
+        num_threads=num_threads,
+    )
+    load_ms = (time.perf_counter() - t0) * 1000
+    logger.info("Model loaded in %.0f ms (threads=%d)", load_ms, num_threads)
+
+    yield
+
+    _engine = None
+
+
+app = FastAPI(title="asr2clip local ASR", lifespan=lifespan)
+
+
+def _error_response(
+    message: str, status_code: int, error_type: str = "invalid_request_error"
+):
+    """Return an OpenAI-style error response."""
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "error": {
+                "message": message,
+                "type": error_type,
+                "param": None,
+                "code": None,
+            }
+        },
+    )
+
+
+@app.post("/v1/audio/transcriptions")
+async def create_transcription(
+    file: UploadFile = File(...),
+    model: str = Form(...),
+    response_format: str = Form("json"),
+    language: str | None = Form(None),
+    prompt: str | None = Form(None),
+    temperature: float = Form(0.0),
+):
+    """Transcribe audio to text (OpenAI-compatible endpoint).
+
+    Args:
+        file: Audio file to transcribe.
+        model: Model name (accepted but ignored; SenseVoice is always used).
+        response_format: Response format: "json", "text", or "verbose_json".
+        language: Language hint (accepted but ignored).
+        prompt: Prompt text (accepted but ignored).
+        temperature: Temperature (accepted but ignored).
+
+    Returns:
+        Transcription result in the requested format.
+    """
+    if _engine is None:
+        return _error_response("ASR engine not initialized", 503, "server_error")
+
+    if response_format not in ("json", "text", "verbose_json"):
+        return _error_response(
+            f"Unsupported response_format: {response_format}. "
+            "Supported values: json, text, verbose_json",
+            400,
+        )
+
+    audio_data = await file.read()
+    if not audio_data:
+        return _error_response("Empty audio file", 400)
+
+    filename = file.filename or "audio.wav"
+
+    try:
+        t0 = time.perf_counter()
+        result = _engine.transcribe(audio_data, filename)
+        infer_ms = (time.perf_counter() - t0) * 1000
+        logger.info(
+            "Transcribed %.1fs audio in %.0f ms: %s",
+            result.duration,
+            infer_ms,
+            result.text[:80],
+        )
+    except Exception as e:
+        logger.exception("Transcription failed")
+        return _error_response(f"Transcription failed: {e}", 500, "server_error")
+
+    if response_format == "text":
+        return PlainTextResponse(result.text)
+
+    if response_format == "verbose_json":
+        return JSONResponse(
+            {
+                "task": "transcribe",
+                "language": language or "auto",
+                "duration": round(result.duration, 2),
+                "text": result.text,
+                "segments": [
+                    {
+                        "id": 0,
+                        "start": 0.0,
+                        "end": round(result.duration, 2),
+                        "text": result.text,
+                    }
+                ],
+            }
+        )
+
+    # Default: json
+    return JSONResponse({"text": result.text})
+
+
+@app.get("/v1/models")
+async def list_models():
+    """List available models (OpenAI-compatible)."""
+    return JSONResponse(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": _model_name,
+                    "object": "model",
+                    "owned_by": "local",
+                }
+            ],
+        }
+    )
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return JSONResponse({"status": "ok" if _engine is not None else "loading"})
+
+
+def run_server(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    model_dir: str | None = None,
+    num_threads: int = 4,
+) -> None:
+    """Start the ASR server.
+
+    Args:
+        host: Bind address.
+        port: Bind port.
+        model_dir: Path to model directory.
+        num_threads: Number of inference threads.
+    """
+    import uvicorn
+
+    configure(model_dir=model_dir, num_threads=num_threads)
+    logger.info("Starting asr2clip local ASR server on %s:%d", host, port)
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
+def run_server_cli() -> None:
+    """CLI entry point for ``asr2clip-serve`` command."""
+    parser = argparse.ArgumentParser(
+        description="Start the asr2clip local ASR server (OpenAI-compatible)",
+    )
+    parser.add_argument(
+        "--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Bind port (default: 8000)"
+    )
+    parser.add_argument("--model-dir", default=None, help="Path to model directory")
+    parser.add_argument(
+        "--num-threads", type=int, default=4, help="Inference threads (default: 4)"
+    )
+    parser.add_argument(
+        "--download-model",
+        action="store_true",
+        help="Download the SenseVoice model and exit",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+
+    if args.download_model:
+        model_dir = resolve_model_dir(args.model_dir)
+        download_model(model_dir)
+        return
+
+    run_server(
+        host=args.host,
+        port=args.port,
+        model_dir=args.model_dir,
+        num_threads=args.num_threads,
+    )

--- a/asr2clip/local_asr/engine.py
+++ b/asr2clip/local_asr/engine.py
@@ -1,0 +1,103 @@
+"""sherpa-onnx ASR engine wrapper for SenseVoice inference."""
+
+import io
+from dataclasses import dataclass
+
+import numpy as np
+from pydub import AudioSegment
+
+import sherpa_onnx
+
+SAMPLE_RATE = 16000
+
+
+@dataclass
+class TranscriptionResult:
+    """Result from ASR inference."""
+
+    text: str
+    duration: float
+
+
+class ASREngine:
+    """Wraps sherpa-onnx OfflineRecognizer for SenseVoice inference.
+
+    Args:
+        model_path: Path to the ONNX model file.
+        tokens_path: Path to the tokens.txt file.
+        num_threads: Number of inference threads.
+    """
+
+    def __init__(self, model_path: str, tokens_path: str, num_threads: int = 4):
+        self.recognizer = sherpa_onnx.OfflineRecognizer.from_sense_voice(
+            model=model_path,
+            tokens=tokens_path,
+            use_itn=True,
+            num_threads=num_threads,
+        )
+
+    def transcribe(
+        self, audio_data: bytes, filename: str = "audio.wav"
+    ) -> TranscriptionResult:
+        """Transcribe audio bytes to text.
+
+        Args:
+            audio_data: Raw audio file bytes (any format supported by pydub/ffmpeg).
+            filename: Original filename, used to determine audio format.
+
+        Returns:
+            TranscriptionResult with text and duration.
+        """
+        audio_array, sr = self._audio_bytes_to_numpy(audio_data, filename)
+        duration = len(audio_array) / sr
+
+        stream = self.recognizer.create_stream()
+        stream.accept_waveform(sr, audio_array)
+        self.recognizer.decode_stream(stream)
+
+        text = stream.result.text.strip()
+        return TranscriptionResult(text=text, duration=duration)
+
+    @staticmethod
+    def _audio_bytes_to_numpy(
+        audio_data: bytes, filename: str
+    ) -> tuple[np.ndarray, int]:
+        """Convert audio bytes to mono float32 numpy array.
+
+        Args:
+            audio_data: Raw audio file bytes.
+            filename: Filename for format detection.
+
+        Returns:
+            Tuple of (audio_array, sample_rate).
+        """
+        buf = io.BytesIO(audio_data)
+
+        # Determine format from extension
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        fmt_map = {
+            "wav": "wav",
+            "mp3": "mp3",
+            "flac": "flac",
+            "ogg": "ogg",
+            "m4a": "m4a",
+            "mp4": "mp4",
+            "mpeg": "mp3",
+            "mpga": "mp3",
+            "webm": "webm",
+        }
+        fmt = fmt_map.get(ext, None)
+
+        if fmt:
+            audio = AudioSegment.from_file(buf, format=fmt)
+        else:
+            audio = AudioSegment.from_file(buf)
+
+        # Convert to mono 16kHz
+        audio = audio.set_channels(1).set_frame_rate(SAMPLE_RATE)
+
+        # Extract raw samples as float32 normalized to [-1, 1]
+        samples = np.array(audio.get_array_of_samples(), dtype=np.float32)
+        samples /= 2 ** (audio.sample_width * 8 - 1)
+
+        return samples, SAMPLE_RATE

--- a/asr2clip/local_asr/model_manager.py
+++ b/asr2clip/local_asr/model_manager.py
@@ -1,0 +1,136 @@
+"""Model download, path resolution, and validation for SenseVoice."""
+
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+import httpx
+
+MODEL_ARCHIVE_URL = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/"
+    "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2"
+)
+MODEL_SUBDIR = "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"
+MODEL_FILENAME = "model.int8.onnx"
+TOKENS_FILENAME = "tokens.txt"
+
+
+def _default_data_dir() -> Path:
+    """Return XDG_DATA_HOME / asr2clip or ~/.local/share/asr2clip."""
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / "asr2clip"
+    return Path.home() / ".local" / "share" / "asr2clip"
+
+
+def resolve_model_dir(model_dir: str | None = None) -> Path:
+    """Resolve the model directory from explicit path, env var, or default.
+
+    Args:
+        model_dir: Explicit path override (highest priority).
+
+    Returns:
+        Resolved model directory path.
+    """
+    if model_dir:
+        return Path(model_dir)
+
+    env = os.environ.get("ASR2CLIP_MODEL_DIR")
+    if env:
+        return Path(env)
+
+    return _default_data_dir() / "models" / MODEL_SUBDIR
+
+
+def get_model_paths(model_dir: Path) -> tuple[Path, Path]:
+    """Return (model_onnx_path, tokens_path) within the model directory.
+
+    Args:
+        model_dir: Path to the model directory.
+
+    Returns:
+        Tuple of (model_path, tokens_path).
+    """
+    return model_dir / MODEL_FILENAME, model_dir / TOKENS_FILENAME
+
+
+def validate_model(model_dir: Path) -> bool:
+    """Check that required model files exist.
+
+    Args:
+        model_dir: Path to the model directory.
+
+    Returns:
+        True if all required files are present.
+    """
+    model_path, tokens_path = get_model_paths(model_dir)
+    return model_path.is_file() and tokens_path.is_file()
+
+
+def download_model(model_dir: Path, force: bool = False) -> Path:
+    """Download and extract the SenseVoice model.
+
+    Args:
+        model_dir: Target directory for the model files.
+        force: If True, re-download even if files exist.
+
+    Returns:
+        Path to the extracted model directory.
+    """
+    if not force and validate_model(model_dir):
+        print(f"Model already exists at {model_dir}", file=sys.stderr)
+        return model_dir
+
+    # Ensure parent directory exists
+    model_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = model_dir.parent / f"{MODEL_SUBDIR}.tar.bz2"
+
+    print("Downloading SenseVoice model (~230 MB)...", file=sys.stderr)
+    print(f"  From: {MODEL_ARCHIVE_URL}", file=sys.stderr)
+    print(f"  To:   {archive_path}", file=sys.stderr)
+
+    try:
+        with httpx.stream(
+            "GET", MODEL_ARCHIVE_URL, follow_redirects=True, timeout=300
+        ) as resp:
+            resp.raise_for_status()
+            total = int(resp.headers.get("content-length", 0))
+            downloaded = 0
+
+            with open(archive_path, "wb") as f:
+                for chunk in resp.iter_bytes(chunk_size=1024 * 1024):
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if total > 0:
+                        pct = downloaded * 100 // total
+                        mb = downloaded / (1024 * 1024)
+                        print(
+                            f"\r  Progress: {mb:.0f} MB ({pct}%)",
+                            end="",
+                            flush=True,
+                            file=sys.stderr,
+                        )
+
+        print(file=sys.stderr)  # newline after progress
+    except httpx.HTTPError as e:
+        print(f"\nDownload failed: {e}", file=sys.stderr)
+        if archive_path.exists():
+            archive_path.unlink()
+        raise SystemExit(1) from e
+
+    print("Extracting...", file=sys.stderr)
+    with tarfile.open(archive_path, "r:bz2") as tar:
+        tar.extractall(path=model_dir.parent)
+
+    archive_path.unlink()
+
+    if not validate_model(model_dir):
+        print(
+            f"Error: Model files not found after extraction in {model_dir}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    print(f"Model ready at {model_dir}", file=sys.stderr)
+    return model_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["asr2clip"]
+packages = ["asr2clip", "asr2clip.local_asr"]
 
 [tool.setuptools.dynamic]
 version = { attr = "asr2clip.__version__" }
@@ -40,6 +40,7 @@ Homepage = "https://github.com/Oaklight/asr2clip"
 
 [project.scripts]
 asr2clip = "asr2clip.asr2clip:main"
+asr2clip-serve = "asr2clip.local_asr:cli_main"
 
 [project.optional-dependencies]
 dev = [
@@ -48,6 +49,12 @@ dev = [
     "ty>=0.0.31",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
+]
+local_asr = [
+    "sherpa-onnx>=1.10.0",
+    "fastapi>=0.100.0",
+    "uvicorn[standard]>=0.20.0",
+    "python-multipart>=0.0.6",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["asr2clip"]
+exclude = ["asr2clip/local_asr"]
 
 [tool.complexipy]
 paths = ["asr2clip"]


### PR DESCRIPTION
## Summary

- Add `local_asr` submodule: a local ASR inference server powered by sherpa-onnx + SenseVoice-Small, exposed as an OpenAI-compatible `/v1/audio/transcriptions` endpoint
- FastAPI server with `POST /v1/audio/transcriptions`, `GET /v1/models`, `GET /health`; supports `json`, `text`, `verbose_json` response formats
- CLI integration via `--serve`, `--download-model`, `--host`, `--port`, `--model-dir`, `--num-threads`; optional deps via `pip install asr2clip[local_asr]`

## Module structure

```
asr2clip/local_asr/
  __init__.py          # dependency check, cli_main entry point
  app.py               # FastAPI app + routes + run_server()
  engine.py            # sherpa-onnx inference wrapper (ASREngine)
  model_manager.py     # model download, path resolution, validation
```

## Test plan

- [x] `pip install -e ".[local_asr]"` installs all deps (sherpa-onnx, fastapi, uvicorn)
- [x] `asr2clip --serve --model-dir <path>` starts server, `/health` returns `{"status": "ok"}`
- [x] `POST /v1/audio/transcriptions` returns correct transcription for en/zh/ja WAV files
- [x] All three `response_format` values (json, text, verbose_json) return correct output
- [x] Error responses follow OpenAI error format (bad format → 400, empty file → 400)
- [x] `asr2clip --test` against local server succeeds
- [x] `ruff check` and `ruff format` pass cleanly