### PR TITLE
refactor: replace pyperclip with copykitten

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,4 @@ jobs:
         run: ty check
 
       - name: Complexity check (complexipy)
-        run: complexipy asr2clip/
+        run: complexipy asr2clip/ -e "_vendor"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Before you begin, ensure you have the following ready:
 |------------|---------|-------|-------|---------|
 | **ffmpeg** | Audio format conversion | `apt install ffmpeg` | `brew install ffmpeg` | [Download](https://ffmpeg.org/download.html) |
 | **PortAudio** | Audio recording | `apt install libportaudio2` | `brew install portaudio` | Included with sounddevice |
-| **Clipboard** | Copy to clipboard | `apt install xclip` (X11) or `wl-clipboard` (Wayland) | Built-in | Built-in |
+| **Clipboard** | Copy to clipboard | Built-in (copykitten) | Built-in | Built-in |
 
 ## Installation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -29,7 +29,7 @@ asr2clip                   # 开始录音和转录
 |------|------|-------|-------|---------|
 | **ffmpeg** | 音频格式转换 | `apt install ffmpeg` | `brew install ffmpeg` | [下载](https://ffmpeg.org/download.html) |
 | **PortAudio** | 音频录制 | `apt install libportaudio2` | `brew install portaudio` | 随 sounddevice 安装 |
-| **剪贴板** | 复制到剪贴板 | `apt install xclip` (X11) 或 `wl-clipboard` (Wayland) | 内置 | 内置 |
+| **剪贴板** | 复制到剪贴板 | 内置 (copykitten) | 内置 | 内置 |
 
 ## 安装
 

--- a/asr2clip/output.py
+++ b/asr2clip/output.py
@@ -1,8 +1,6 @@
 """Output handling for asr2clip (clipboard, file, stdout)."""
 
 import os
-import shutil
-import sys
 from datetime import datetime
 
 from .utils import log, print_success, warning
@@ -14,27 +12,13 @@ def check_clipboard_support() -> bool:
     Returns:
         True if clipboard is supported, False otherwise.
     """
-    # Check for xclip (X11)
-    if shutil.which("xclip"):
-        return True
+    try:
+        import copykitten
 
-    # Check for wl-copy (Wayland)
-    if shutil.which("wl-copy"):
+        copykitten.copy("")
         return True
-
-    # Check for xsel (X11 alternative)
-    if shutil.which("xsel"):
-        return True
-
-    # On macOS, pbcopy is always available
-    if sys.platform == "darwin":
-        return True
-
-    # On Windows, clipboard is always available
-    if sys.platform == "win32":
-        return True
-
-    return False
+    except Exception:
+        return False
 
 
 def copy_to_clipboard(text: str) -> bool:
@@ -47,9 +31,9 @@ def copy_to_clipboard(text: str) -> bool:
         True if successful, False otherwise.
     """
     try:
-        import pyperclip
+        import copykitten
 
-        pyperclip.copy(text)
+        copykitten.copy(text)
         return True
     except Exception as e:
         warning(f"Clipboard error: {e}")
@@ -121,8 +105,5 @@ def output_transcript(
 
 def print_clipboard_help():
     """Print help message for clipboard setup."""
-    print("\nClipboard support requires one of the following:")
-    print("  - xclip (X11): sudo apt install xclip")
-    print("  - wl-clipboard (Wayland): sudo apt install wl-clipboard")
-    print("  - xsel (X11): sudo apt install xsel")
-    print("\nAlternatively, use --output to save transcripts to a file.")
+    print("\nClipboard is handled by copykitten (no external tools needed).")
+    print("If clipboard is unavailable, use --output to save transcripts to a file.")

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
   - pip:
       - numpy==1.24.4
       - openai==1.59.6
-      - pyperclip==1.9.0
+      - copykitten>=1.0.0
       - pyyaml==6.0.2
       - requests==2.32.3
       - scipy==1.10.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.24.4",
-    "pyperclip>=1.9.0",
+    "copykitten>=1.0.0",
     "sounddevice>=0.5.1",
     "pydub>=0.25.1",
     "audioop-lts>=0.2.1; python_version>='3.13'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,5 +77,5 @@ exclude = ["asr2clip/local_asr", "asr2clip/_vendor"]
 
 [tool.complexipy]
 paths = ["asr2clip"]
-exclude = ["asr2clip/_vendor"]
+exclude = ["_vendor"]
 max-complexity-allowed = 15


### PR DESCRIPTION
## Summary

- Replace pyperclip (unmaintained since 2021) with copykitten (Rust arboard, 105 stars, actively maintained)
- copykitten talks to platform clipboard APIs directly — no xclip/xsel/wl-clipboard needed on Linux
- Pre-built `cp38-abi3` wheels for all platforms: Linux x86_64/ARM64, macOS x86_64/ARM64, Windows x64
- Headless environments now get a clean error instead of hanging indefinitely

## Test plan

- [x] `check_clipboard_support()` returns `True` on graphical session
- [x] `copy_to_clipboard()` copies text, verified with `copykitten.paste()`
- [x] Headless (`DISPLAY`/`WAYLAND_DISPLAY` unset): returns `False` immediately, no hang
- [x] `ruff check` and `ruff format` pass