### PR TITLE
feat: replace numpy VAD with Silero VAD via sherpa-onnx

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,8 @@ asr2clip -i audio.mp3      # Transcribe an audio file
 ```
 usage: asr2clip [-h] [-v] [-c FILE] [-q] [-i FILE] [-o FILE] [--test]
                 [--list_devices] [--device DEV] [-e] [--generate_config]
-                [--print_config] [--vad] [--interval SEC] [--adaptive]
-                [--calibrate] [--silence_threshold RMS]
-                [--silence_duration SEC] [--no_adaptive]
+                [--print_config] [--vad] [--interval SEC]
+                [--silence_threshold PROB] [--silence_duration SEC]
 
 Record audio and transcribe to clipboard using ASR API
 
@@ -150,13 +149,10 @@ options:
   --print_config        Print template configuration to stdout
   --vad                 Continuous recording with voice activity detection
   --interval SEC        Continuous recording with fixed interval (seconds)
-  --adaptive            Adaptive threshold (default when --vad is used)
-  --calibrate           Calibrate silence threshold from ambient noise
-  --silence_threshold RMS
-                        Silence threshold (default: auto with adaptive)
+  --silence_threshold PROB
+                        VAD speech probability threshold, 0.0-1.0 (default: 0.5)
   --silence_duration SEC
                         Silence duration to trigger transcription (default: 1.5)
-  --no_adaptive         Disable adaptive threshold (use fixed threshold)
 ```
 
 ### Examples
@@ -198,35 +194,35 @@ In continuous mode:
 
 ### Voice Activity Detection (VAD)
 
+VAD uses the [Silero VAD](https://github.com/snakers4/silero-vad) neural network model via sherpa-onnx for reliable speech detection. Requires the `vad` extra:
+
+```bash
+pip install asr2clip[vad]
+```
+
 Enable automatic transcription when you stop speaking:
 
 ```bash
 # Auto-transcribe when silence is detected
-asr2clip --daemon --vad
+asr2clip --vad
 
-# Calibrate silence threshold for your environment
-asr2clip --calibrate
+# Use custom settings
+asr2clip --vad --silence_threshold 0.3 --silence_duration 2.0
 
-# Use custom silence settings
-asr2clip --daemon --vad --silence_threshold 0.005 --silence_duration 2.0
+# Save transcripts to file
+asr2clip --vad -o ~/meeting.txt
 ```
 
 VAD options:
 - `--vad`: Enable voice activity detection
-- `--adaptive`: Enable adaptive threshold that adjusts to ambient noise on-the-fly
-- `--calibrate`: Measure ambient noise and suggest threshold
-- `--silence_threshold`: RMS threshold for silence (default: 0.01)
+- `--silence_threshold`: Speech probability threshold, 0.0-1.0 (default: 0.5). Lower values are more sensitive.
 - `--silence_duration`: Seconds of silence to trigger transcription (default: 1.5)
 
 With VAD enabled, transcription is triggered when:
-1. Speech is detected (audio above threshold)
-2. Followed by silence (audio below threshold for the specified duration)
+1. Speech is detected (audio probability above threshold)
+2. Followed by silence (below threshold for the specified duration)
 
-Tip: Use `--adaptive` for automatic threshold adjustment during recording:
-```bash
-asr2clip --daemon --vad --adaptive
-```
-This continuously monitors ambient noise and adjusts the threshold accordingly.
+The Silero VAD model (~629 KB) is downloaded automatically on first use.
 
 ## Troubleshooting
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -126,9 +126,8 @@ asr2clip -i audio.mp3      # 转录音频文件
 ```
 用法: asr2clip [-h] [-v] [-c FILE] [-q] [-i FILE] [-o FILE] [--test]
                [--list_devices] [--device DEV] [-e] [--generate_config]
-               [--print_config] [--vad] [--interval SEC] [--adaptive]
-               [--calibrate] [--silence_threshold RMS]
-               [--silence_duration SEC] [--no_adaptive]
+               [--print_config] [--vad] [--interval SEC]
+               [--silence_threshold PROB] [--silence_duration SEC]
 
 录音并使用 ASR API 转录到剪贴板
 
@@ -150,13 +149,10 @@ asr2clip -i audio.mp3      # 转录音频文件
   --print_config        打印配置模板到 stdout
   --vad                 持续录音，启用语音活动检测
   --interval SEC        持续录音，固定间隔转录（秒）
-  --adaptive            自适应阈值（使用 --vad 时默认启用）
-  --calibrate           从环境噪音校准静音阈值
-  --silence_threshold RMS
-                        静音阈值（默认：自适应自动调整）
+  --silence_threshold PROB
+                        VAD 语音概率阈值，0.0-1.0（默认：0.5）
   --silence_duration SEC
                         触发转录的静音时长（默认：1.5）
-  --no_adaptive         禁用自适应阈值（使用固定阈值）
 ```
 
 ### 示例
@@ -198,37 +194,35 @@ asr2clip --vad --interval 120 -o ~/meeting.txt
 
 ### 语音活动检测（VAD）
 
+VAD 使用 [Silero VAD](https://github.com/snakers4/silero-vad) 神经网络模型（通过 sherpa-onnx）进行可靠的语音检测。需要安装 `vad` 额外依赖：
+
+```bash
+pip install asr2clip[vad]
+```
+
 启用静音检测，在您停止说话时自动转录：
 
 ```bash
 # 检测到静音时自动转录
-asr2clip --daemon --vad
+asr2clip --vad
 
-# 校准静音阈值（测量环境噪音）
-asr2clip --calibrate
+# 使用自定义设置
+asr2clip --vad --silence_threshold 0.3 --silence_duration 2.0
 
-# 启用自适应阈值（实时调整）
-asr2clip --daemon --vad --adaptive
-
-# 使用自定义静音设置
-asr2clip --daemon --vad --silence_threshold 0.005 --silence_duration 2.0
+# 保存转录结果到文件
+asr2clip --vad -o ~/meeting.txt
 ```
 
 VAD 选项：
 - `--vad`：启用语音活动检测
-- `--adaptive`：启用自适应阈值，实时根据环境噪音调整
-- `--calibrate`：测量环境噪音并建议阈值
-- `--silence_threshold`：静音 RMS 阈值（默认：0.01）
+- `--silence_threshold`：语音概率阈值，0.0-1.0（默认：0.5）。值越低越敏感。
 - `--silence_duration`：触发转录的静音时长（秒，默认：1.5）
 
-提示：使用 `--adaptive` 可以在录音过程中自动调整阈值：
-```bash
-asr2clip --daemon --vad --adaptive
-```
-
 启用 VAD 后，转录在以下情况触发：
-1. 检测到语音（音频高于阈值）
-2. 随后是静音（音频低于阈值持续指定时长）
+1. 检测到语音（音频概率高于阈值）
+2. 随后是静音（低于阈值持续指定时长）
+
+Silero VAD 模型（~629 KB）将在首次使用时自动下载。
 
 ## 故障排除
 

--- a/asr2clip/asr2clip.py
+++ b/asr2clip/asr2clip.py
@@ -423,7 +423,7 @@ def main():
         api_key, api_base_url, model_name, org_id = get_api_config(config)
         if args.vad:
             try:
-                import sherpa_onnx  # noqa: F401
+                import sherpa_onnx  # noqa: F401  # type: ignore[unresolved-import]
             except ImportError:
                 print(
                     "Error: VAD requires sherpa-onnx.\n"

--- a/asr2clip/asr2clip.py
+++ b/asr2clip/asr2clip.py
@@ -423,7 +423,7 @@ def main():
         api_key, api_base_url, model_name, org_id = get_api_config(config)
         if args.vad:
             try:
-                import sherpa_onnx  # noqa: F401  # type: ignore[unresolved-import]
+                __import__("sherpa_onnx")
             except ImportError:
                 print(
                     "Error: VAD requires sherpa-onnx.\n"

--- a/asr2clip/asr2clip.py
+++ b/asr2clip/asr2clip.py
@@ -211,7 +211,6 @@ Setup:
   asr2clip --generate_config       # Create new config file
   asr2clip --test                  # Test API connection
   asr2clip --list_devices          # List audio devices
-  asr2clip --calibrate             # Calibrate silence threshold
 
 Local ASR server:
   asr2clip --serve                 # Start local ASR server on :8000
@@ -288,21 +287,11 @@ Local ASR server:
         help="Continuous recording with fixed interval (seconds)",
     )
     parser.add_argument(
-        "--adaptive",
-        action="store_true",
-        help="Adaptive threshold (default when --vad is used)",
-    )
-    parser.add_argument(
-        "--calibrate",
-        action="store_true",
-        help="Calibrate silence threshold from ambient noise",
-    )
-    parser.add_argument(
         "--silence_threshold",
         type=float,
-        metavar="RMS",
+        metavar="PROB",
         default=None,
-        help="Silence threshold (default: auto with adaptive)",
+        help="VAD speech probability threshold, 0.0-1.0 (default: 0.5)",
     )
     parser.add_argument(
         "--silence_duration",
@@ -310,11 +299,6 @@ Local ASR server:
         metavar="SEC",
         default=1.5,
         help="Silence duration to trigger transcription (default: 1.5)",
-    )
-    parser.add_argument(
-        "--no_adaptive",
-        action="store_true",
-        help="Disable adaptive threshold (use fixed threshold)",
     )
 
     # Local ASR server
@@ -364,20 +348,8 @@ def _validate_args(args: argparse.Namespace):
     Raises:
         SystemExit: On invalid argument combinations.
     """
-    if args.adaptive and not args.vad:
-        print("Error: --adaptive requires --vad")
-        sys.exit(1)
-
-    if args.no_adaptive and not args.vad:
-        print("Error: --no_adaptive requires --vad")
-        sys.exit(1)
-
-    # Auto-enable adaptive when VAD is used, unless user specified threshold or --no_adaptive
-    if args.vad and not args.no_adaptive and args.silence_threshold is None:
-        args.adaptive = True
-
     if args.silence_threshold is None:
-        args.silence_threshold = 0.01
+        args.silence_threshold = 0.5
 
     if args.interval is None:
         args.interval = 30.0
@@ -447,15 +419,17 @@ def main():
 
     device = get_audio_device(config, args.device)
 
-    if args.calibrate:
-        from .vad import calibrate_silence_threshold
-
-        threshold = calibrate_silence_threshold(device=device)
-        print(f"\nUse this threshold with: --silence_threshold {threshold:.4f}")
-        return
-
     if args.vad or args.interval is not None:
         api_key, api_base_url, model_name, org_id = get_api_config(config)
+        if args.vad:
+            try:
+                import sherpa_onnx  # noqa: F401
+            except ImportError:
+                print(
+                    "Error: VAD requires sherpa-onnx.\n"
+                    "Install with: pip install asr2clip[vad]"
+                )
+                sys.exit(1)
         continuous_recording(
             api_key=api_key,
             api_base_url=api_base_url,
@@ -467,7 +441,6 @@ def main():
             vad_enabled=args.vad,
             silence_threshold=args.silence_threshold,
             silence_duration=args.silence_duration,
-            adaptive_threshold=args.adaptive,
         )
         return
 

--- a/asr2clip/daemon.py
+++ b/asr2clip/daemon.py
@@ -21,7 +21,10 @@ from .utils import (
     setup_signal_handlers,
     warning,
 )
-from .vad import VoiceActivityDetector, calibrate_silence_threshold
+from .vad import VoiceActivityDetector
+
+# RMS threshold for silence filtering in interval-only mode (no VAD)
+_INTERVAL_SILENCE_RMS = 0.005
 
 
 @dataclass
@@ -47,9 +50,8 @@ class RecorderConfig:
     output_file: str | None = None
     sample_rate: int = 16000
     vad_enabled: bool = False
-    silence_threshold: float = 0.01
+    silence_threshold: float = 0.5
     silence_duration: float = 1.5
-    adaptive_threshold: bool = False
     min_transcribe_interval: float = 0.5
     max_concurrent_transcriptions: int = 3
 
@@ -71,22 +73,6 @@ class RecorderState:
     vad: VoiceActivityDetector | None = None
 
 
-def _calibrate_threshold(cfg: RecorderConfig) -> float:
-    """Calibrate silence threshold from ambient noise.
-
-    Args:
-        cfg: Recorder configuration.
-
-    Returns:
-        Calibrated silence threshold.
-    """
-    info("Calibrating ambient noise level...")
-    calibrated = calibrate_silence_threshold(
-        device=cfg.device, duration=1.0, sample_rate=cfg.sample_rate
-    )
-    return max(calibrated, 0.001)
-
-
 def _log_startup(cfg: RecorderConfig):
     """Log startup information.
 
@@ -95,12 +81,9 @@ def _log_startup(cfg: RecorderConfig):
     """
     if cfg.vad_enabled:
         info(
-            f"Starting continuous recording with VAD (silence: {cfg.silence_duration}s)"
+            f"Starting continuous recording with VAD "
+            f"(threshold: {cfg.silence_threshold}, silence: {cfg.silence_duration}s)"
         )
-        if cfg.adaptive_threshold:
-            info(f"Adaptive threshold enabled (base: {cfg.silence_threshold:.4f})")
-        else:
-            info(f"Silence threshold: {cfg.silence_threshold:.4f}")
     else:
         info(f"Starting continuous recording mode (interval: {cfg.interval}s)")
     info("Press Ctrl+C to stop")
@@ -231,12 +214,9 @@ def _transcribe_chunks(
     if duration < 0.5:
         return
 
-    if not skip_silence_check:
+    if not skip_silence_check and state.vad is None:
         rms = calculate_rms(audio_data)
-        threshold = (
-            state.vad.get_current_threshold() if state.vad else cfg.silence_threshold
-        )
-        if rms < threshold:
+        if rms < _INTERVAL_SILENCE_RMS:
             state.last_transcribe_time = time.time()
             return
 
@@ -336,9 +316,8 @@ def continuous_recording(
     output_file: str | None = None,
     sample_rate: int = 16000,
     vad_enabled: bool = False,
-    silence_threshold: float = 0.01,
+    silence_threshold: float = 0.5,
     silence_duration: float = 1.5,
-    adaptive_threshold: bool = False,
     min_transcribe_interval: float = 0.5,
     max_concurrent_transcriptions: int = 3,
 ):
@@ -358,9 +337,8 @@ def continuous_recording(
         output_file: Optional file to append transcripts to.
         sample_rate: Sample rate in Hz.
         vad_enabled: Enable voice activity detection.
-        silence_threshold: RMS threshold for silence detection.
+        silence_threshold: Silero speech probability threshold (0.0-1.0).
         silence_duration: Duration of silence to trigger transcription.
-        adaptive_threshold: Enable adaptive threshold based on ambient noise.
         min_transcribe_interval: Minimum interval between transcription triggers (seconds).
         max_concurrent_transcriptions: Maximum number of concurrent transcription requests.
     """
@@ -378,13 +356,9 @@ def continuous_recording(
         vad_enabled=vad_enabled,
         silence_threshold=silence_threshold,
         silence_duration=silence_duration,
-        adaptive_threshold=adaptive_threshold,
         min_transcribe_interval=min_transcribe_interval,
         max_concurrent_transcriptions=max_concurrent_transcriptions,
     )
-
-    if vad_enabled and adaptive_threshold and silence_threshold == 0.01:
-        cfg.silence_threshold = _calibrate_threshold(cfg)
 
     _log_startup(cfg)
 
@@ -392,9 +366,8 @@ def continuous_recording(
     if vad_enabled:
         state.vad = VoiceActivityDetector(
             sample_rate=sample_rate,
-            silence_threshold=cfg.silence_threshold,
+            threshold=cfg.silence_threshold,
             silence_duration=silence_duration,
-            adaptive=adaptive_threshold,
         )
 
     executor = ThreadPoolExecutor(max_workers=max_concurrent_transcriptions)

--- a/asr2clip/vad.py
+++ b/asr2clip/vad.py
@@ -1,401 +1,198 @@
-"""Voice Activity Detection (VAD) for asr2clip.
+"""Voice Activity Detection (VAD) using Silero VAD via sherpa-onnx.
 
-Multi-feature VAD using numpy only (no extra dependencies).
-Combines RMS energy, zero-crossing rate, and spectral features for robust detection.
+Requires the ``sherpa-onnx`` package (install with ``pip install asr2clip[vad]``).
+The Silero VAD model (~629 KB) is downloaded automatically on first use.
 """
+
+import os
+import sys
+import threading
+from pathlib import Path
 
 import numpy as np
 
-from .utils import debug
+VAD_MODEL_URL = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/silero_vad.onnx"
+)
+VAD_MODEL_FILENAME = "silero_vad.onnx"
 
 # Default VAD parameters
-DEFAULT_SILENCE_THRESHOLD = 0.01  # RMS threshold for silence
+DEFAULT_THRESHOLD = 0.5  # Silero speech probability threshold
 DEFAULT_SILENCE_DURATION = 1.5  # Seconds of silence to trigger transcription
-DEFAULT_MIN_SPEECH_DURATION = 0.5  # Minimum speech duration to transcribe
-DEFAULT_ADAPTIVE_WINDOW = 5.0  # Seconds of audio to use for adaptive threshold
-DEFAULT_MAX_SPEECH_DURATION = 30.0  # Max speech duration before forced transcription
-DEFAULT_SPEECH_GAP_TOLERANCE = 0.3  # Max gap in speech before resetting (seconds)
+DEFAULT_MIN_SPEECH_DURATION = 0.25  # Minimum speech duration for a valid segment
+DEFAULT_MAX_SPEECH_DURATION = 30.0  # Max duration before forced transcription
 
-# Speech frequency band (Hz)
-SPEECH_FREQ_LOW = 300
-SPEECH_FREQ_HIGH = 3000
 
-# Zero-crossing rate threshold (speech typically has lower ZCR than noise)
-DEFAULT_ZCR_THRESHOLD = 0.3
+def _default_data_dir() -> Path:
+    """Return XDG_DATA_HOME / asr2clip or ~/.local/share/asr2clip."""
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / "asr2clip"
+    return Path.home() / ".local" / "share" / "asr2clip"
 
-# Minimum speech band energy ratio
-DEFAULT_SPEECH_BAND_RATIO = 0.2
+
+def _resolve_vad_model() -> Path:
+    """Return path to silero_vad.onnx, downloading if needed."""
+    model_path = _default_data_dir() / "models" / VAD_MODEL_FILENAME
+    if model_path.is_file():
+        return model_path
+    return _download_vad_model(model_path)
+
+
+def _download_vad_model(model_path: Path) -> Path:
+    """Download the Silero VAD ONNX model.
+
+    Args:
+        model_path: Target path to save the model file.
+
+    Returns:
+        Path to the downloaded model.
+    """
+    from asr2clip._vendor.httpclient import httpclient
+
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    print("Downloading Silero VAD model (~629 KB)...", file=sys.stderr)
+    print(f"  From: {VAD_MODEL_URL}", file=sys.stderr)
+    print(f"  To:   {model_path}", file=sys.stderr)
+
+    try:
+        with httpclient.get(VAD_MODEL_URL, stream=True, timeout=60) as resp:
+            resp.raise_for_status()
+            with open(model_path, "wb") as f:
+                for chunk in resp.iter_bytes(chunk_size=64 * 1024):
+                    f.write(chunk)
+    except httpclient.HTTPError as e:
+        print(f"\nDownload failed: {e}", file=sys.stderr)
+        if model_path.exists():
+            model_path.unlink()
+        raise SystemExit(1) from e
+
+    print("VAD model ready.", file=sys.stderr)
+    return model_path
 
 
 class VoiceActivityDetector:
-    """Multi-feature Voice Activity Detector.
+    """Silero VAD wrapper for real-time speech detection.
 
-    Detects speech using multiple features:
-    - RMS energy: Basic volume detection
-    - Zero-crossing rate: Distinguishes speech from noise
-    - Spectral band energy: Filters non-speech frequencies
-
-    Triggers transcription when speech is followed by silence.
+    Buffers incoming audio into fixed-size windows required by Silero,
+    and emits a trigger when a speech segment (speech followed by silence)
+    is detected or a maximum duration is exceeded.
     """
 
     def __init__(
         self,
         sample_rate: int = 16000,
-        silence_threshold: float = DEFAULT_SILENCE_THRESHOLD,
+        threshold: float = DEFAULT_THRESHOLD,
         silence_duration: float = DEFAULT_SILENCE_DURATION,
         min_speech_duration: float = DEFAULT_MIN_SPEECH_DURATION,
-        adaptive: bool = False,
-        adaptive_window: float = DEFAULT_ADAPTIVE_WINDOW,
-        use_spectral: bool = True,
         max_speech_duration: float = DEFAULT_MAX_SPEECH_DURATION,
-        speech_gap_tolerance: float = DEFAULT_SPEECH_GAP_TOLERANCE,
     ):
-        """Initialize the VAD.
+        """Initialize the Silero VAD.
 
         Args:
             sample_rate: Audio sample rate in Hz.
-            silence_threshold: RMS threshold below which audio is considered silence.
-            silence_duration: Duration of silence (seconds) to trigger transcription.
-            min_speech_duration: Minimum speech duration (seconds) to transcribe.
-            adaptive: Enable adaptive threshold based on ambient noise.
-            adaptive_window: Window size (seconds) for adaptive threshold calculation.
-            use_spectral: Enable spectral analysis for better noise rejection.
-            max_speech_duration: Maximum speech duration before forced transcription.
-            speech_gap_tolerance: Maximum gap in speech before resetting speech state.
+            threshold: Speech probability threshold (0.0-1.0).
+            silence_duration: Seconds of silence after speech to trigger.
+            min_speech_duration: Minimum speech duration for a valid segment.
+            max_speech_duration: Forced trigger after this many seconds.
         """
-        self.sample_rate = sample_rate
-        self.silence_threshold = silence_threshold
-        self.base_threshold = silence_threshold
-        self.silence_duration = silence_duration
-        self.min_speech_duration = min_speech_duration
-        self.adaptive = adaptive
-        self.adaptive_window = adaptive_window
-        self.use_spectral = use_spectral
-        self.max_speech_duration = max_speech_duration
-        self.speech_gap_tolerance = speech_gap_tolerance
+        try:
+            import sherpa_onnx
+        except ImportError as e:
+            raise ImportError(
+                "sherpa-onnx is required for VAD. "
+                "Install with: pip install asr2clip[vad]"
+            ) from e
 
-        # State
-        self.silence_samples = 0
-        self.speech_samples = 0
-        self.is_speaking = False
-        self.total_samples = 0  # Total samples since last transcription
+        model_path = _resolve_vad_model()
 
-        # Adaptive threshold state
-        self.rms_history = []
-        self.max_history_samples = int(
-            adaptive_window * sample_rate / 1024
-        )  # ~1024 samples per chunk
+        config = sherpa_onnx.VadModelConfig()
+        config.silero_vad.model = str(model_path)
+        config.silero_vad.threshold = threshold
+        config.silero_vad.min_silence_duration = silence_duration
+        config.silero_vad.min_speech_duration = min_speech_duration
+        config.sample_rate = sample_rate
 
-        # ZCR adaptive state
-        self.zcr_history = []
-        self.zcr_threshold = DEFAULT_ZCR_THRESHOLD
+        self._vad = sherpa_onnx.VoiceActivityDetector(config, buffer_size_in_seconds=60)
+        self._window_size = config.silero_vad.window_size
+        self._sample_rate = sample_rate
+        self._threshold = threshold
+        self._max_speech_duration = max_speech_duration
 
-    def reset(self):
-        """Reset the VAD state (keeps adaptive threshold history)."""
-        self.silence_samples = 0
-        self.speech_samples = 0
-        self.is_speaking = False
-        self.total_samples = 0
-
-    def reset_adaptive(self):
-        """Reset adaptive threshold history."""
-        self.rms_history = []
-        self.zcr_history = []
-        self.silence_threshold = self.base_threshold
-        self.zcr_threshold = DEFAULT_ZCR_THRESHOLD
-
-    def update_adaptive_threshold(self, rms: float, zcr: float):
-        """Update adaptive thresholds based on recent values.
-
-        Uses the lower percentile of recent values as the noise floor,
-        then sets threshold slightly above it.
-
-        Args:
-            rms: Current RMS value.
-            zcr: Current zero-crossing rate.
-        """
-        if not self.adaptive:
-            return
-
-        self.rms_history.append(rms)
-        self.zcr_history.append(zcr)
-
-        # Keep only recent history
-        if len(self.rms_history) > self.max_history_samples:
-            self.rms_history = self.rms_history[-self.max_history_samples :]
-            self.zcr_history = self.zcr_history[-self.max_history_samples :]
-
-        # Need enough samples for reliable estimate
-        if len(self.rms_history) < 10:
-            return
-
-        # RMS: Use 20th percentile as noise floor estimate
-        sorted_rms = sorted(self.rms_history)
-        noise_floor_idx = int(len(sorted_rms) * 0.2)
-        noise_floor = sorted_rms[noise_floor_idx]
-
-        # Set threshold at 2x noise floor, with minimum of 0.001
-        new_rms_threshold = max(noise_floor * 2.0, 0.001)
-
-        # ZCR: Use 80th percentile as noise ZCR estimate (noise has higher ZCR)
-        sorted_zcr = sorted(self.zcr_history)
-        noise_zcr_idx = int(len(sorted_zcr) * 0.8)
-        noise_zcr = sorted_zcr[noise_zcr_idx]
-
-        # Set ZCR threshold slightly below noise ZCR
-        new_zcr_threshold = min(noise_zcr * 0.9, DEFAULT_ZCR_THRESHOLD)
-
-        # Smooth the threshold updates
-        self.silence_threshold = 0.9 * self.silence_threshold + 0.1 * new_rms_threshold
-        self.zcr_threshold = 0.9 * self.zcr_threshold + 0.1 * new_zcr_threshold
-
-    def calculate_rms(self, audio_chunk: np.ndarray) -> float:
-        """Calculate RMS of audio chunk.
-
-        Args:
-            audio_chunk: Audio data as numpy array.
-
-        Returns:
-            RMS value.
-        """
-        if len(audio_chunk) == 0:
-            return 0.0
-        # Flatten if multi-channel
-        if audio_chunk.ndim > 1:
-            audio_chunk = audio_chunk.flatten()
-        return float(np.sqrt(np.mean(audio_chunk**2)))
-
-    def calculate_zcr(self, audio_chunk: np.ndarray) -> float:
-        """Calculate zero-crossing rate of audio chunk.
-
-        Zero-crossing rate is the rate at which the signal changes sign.
-        Speech typically has lower ZCR than noise.
-
-        Args:
-            audio_chunk: Audio data as numpy array.
-
-        Returns:
-            Zero-crossing rate (0.0 to 1.0).
-        """
-        if len(audio_chunk) < 2:
-            return 0.0
-        # Flatten if multi-channel
-        if audio_chunk.ndim > 1:
-            audio_chunk = audio_chunk.flatten()
-
-        # Count sign changes
-        signs = np.sign(audio_chunk)
-        sign_changes = np.sum(np.abs(np.diff(signs)) > 0)
-
-        # Normalize by length
-        return float(sign_changes / (len(audio_chunk) - 1))
-
-    def calculate_speech_band_ratio(self, audio_chunk: np.ndarray) -> float:
-        """Calculate the ratio of energy in speech frequency band.
-
-        Speech is primarily in 300-3000 Hz range. This helps filter out
-        low-frequency rumble and high-frequency noise.
-
-        Args:
-            audio_chunk: Audio data as numpy array.
-
-        Returns:
-            Ratio of energy in speech band (0.0 to 1.0).
-        """
-        if len(audio_chunk) < 256:
-            return 1.0  # Too short for reliable FFT, assume speech
-
-        # Flatten if multi-channel
-        if audio_chunk.ndim > 1:
-            audio_chunk = audio_chunk.flatten()
-
-        # Compute FFT
-        fft = np.fft.rfft(audio_chunk)
-        freqs = np.fft.rfftfreq(len(audio_chunk), 1.0 / self.sample_rate)
-        power = np.abs(fft) ** 2
-
-        # Calculate total energy
-        total_energy = np.sum(power)
-        if total_energy == 0:
-            return 0.0
-
-        # Calculate energy in speech band
-        speech_mask = (freqs >= SPEECH_FREQ_LOW) & (freqs <= SPEECH_FREQ_HIGH)
-        speech_energy = np.sum(power[speech_mask])
-
-        return float(speech_energy / total_energy)
-
-    def is_speech(self, audio_chunk: np.ndarray) -> tuple[bool, float, float, float]:
-        """Determine if audio chunk contains speech.
-
-        Uses multiple features for robust detection:
-        1. RMS energy must exceed threshold
-        2. ZCR must be below threshold (speech has lower ZCR than noise)
-        3. Speech band energy ratio must be significant (if spectral enabled)
-
-        Args:
-            audio_chunk: Audio data as numpy array.
-
-        Returns:
-            Tuple of (is_speech, rms, zcr, band_ratio).
-        """
-        rms = self.calculate_rms(audio_chunk)
-        zcr = self.calculate_zcr(audio_chunk)
-
-        # Check RMS threshold
-        if rms <= self.silence_threshold:
-            return False, rms, zcr, 0.0
-
-        # Check ZCR (speech has lower ZCR than noise)
-        if zcr > self.zcr_threshold:
-            return False, rms, zcr, 0.0
-
-        # Check spectral features if enabled
-        if self.use_spectral:
-            band_ratio = self.calculate_speech_band_ratio(audio_chunk)
-            if band_ratio < DEFAULT_SPEECH_BAND_RATIO:
-                return False, rms, zcr, band_ratio
-        else:
-            band_ratio = 1.0
-
-        return True, rms, zcr, band_ratio
+        self._buffer = np.empty(0, dtype=np.float32)
+        self._total_samples = 0
+        self._speech_detected = False
+        self._lock = threading.Lock()
 
     def process_chunk(self, audio_chunk: np.ndarray) -> bool:
-        """Process an audio chunk and detect if transcription should be triggered.
+        """Process an audio chunk and detect if transcription should trigger.
 
         Args:
             audio_chunk: Audio data as numpy array.
 
         Returns:
-            True if transcription should be triggered (speech followed by silence).
+            True if transcription should be triggered.
         """
-        chunk_samples = (
-            len(audio_chunk.flatten()) if audio_chunk.ndim > 1 else len(audio_chunk)
-        )
-        self.total_samples += chunk_samples
+        with self._lock:
+            chunk = audio_chunk.flatten().astype(np.float32)
+            self._buffer = np.concatenate([self._buffer, chunk])
+            self._total_samples += len(chunk)
 
-        # Multi-feature speech detection
-        speech_detected, rms, zcr, _ = self.is_speech(audio_chunk)
+            trigger = False
+            while len(self._buffer) >= self._window_size:
+                window = self._buffer[: self._window_size]
+                self._buffer = self._buffer[self._window_size :]
+                self._vad.accept_waveform(window)
 
-        # Update adaptive thresholds
-        self.update_adaptive_threshold(rms, zcr)
+                while not self._vad.empty():
+                    self._vad.pop()
+                    self._speech_detected = True
+                    trigger = True
 
-        if speech_detected:
-            # Speech detected
-            self.speech_samples += chunk_samples
-            self.silence_samples = 0
-            self.is_speaking = True
-        else:
-            # Silence or noise detected
-            self.silence_samples += chunk_samples
-
-            # Check for speech gap tolerance - if silence exceeds gap tolerance
-            # but we haven't accumulated enough speech, reset speech state
-            gap_seconds = self.silence_samples / self.sample_rate
-            speech_seconds = self.speech_samples / self.sample_rate
-
+            # Force trigger on max duration
             if (
-                self.is_speaking
-                and gap_seconds > self.speech_gap_tolerance
-                and speech_seconds < self.min_speech_duration
+                not trigger
+                and self._speech_detected
+                and self._total_samples / self._sample_rate >= self._max_speech_duration
             ):
-                # Short noise burst followed by silence - reset speech state
-                self.speech_samples = 0
-                self.is_speaking = False
+                trigger = True
 
-        # Check if we should trigger transcription
-        silence_seconds = self.silence_samples / self.sample_rate
-        speech_seconds = self.speech_samples / self.sample_rate
-        total_seconds = self.total_samples / self.sample_rate
+            return trigger
 
-        # Trigger conditions:
-        # 1. Normal: speech followed by sufficient silence
-        # 2. Forced: max speech duration exceeded
-        should_trigger = False
+    def reset(self):
+        """Reset VAD state after transcription.
 
-        if self.is_speaking and speech_seconds >= self.min_speech_duration:
-            if silence_seconds >= self.silence_duration:
-                # Normal trigger: speech followed by silence
-                should_trigger = True
-            elif total_seconds >= self.max_speech_duration:
-                # Forced trigger: max duration exceeded
-                should_trigger = True
-
-        if should_trigger:
-            self.reset()
-            return True
-
-        return False
-
-    def get_speech_duration(self) -> float:
-        """Get the current accumulated speech duration in seconds.
-
-        Returns:
-            Speech duration in seconds.
+        Preserves the audio buffer (partial window data belongs to the
+        next segment) but resets counters and flushes Silero state.
         """
-        return self.speech_samples / self.sample_rate
-
-    def get_silence_duration(self) -> float:
-        """Get the current accumulated silence duration in seconds.
-
-        Returns:
-            Silence duration in seconds.
-        """
-        return self.silence_samples / self.sample_rate
+        with self._lock:
+            self._total_samples = 0
+            self._speech_detected = False
+            self._vad.flush()
+            # Drain any segments produced by flush
+            while not self._vad.empty():
+                self._vad.pop()
 
     def get_current_threshold(self) -> float:
-        """Get the current silence threshold.
+        """Return the Silero speech probability threshold.
 
         Returns:
-            Current silence threshold (may differ from initial if adaptive).
+            Probability threshold (0.0-1.0).
         """
-        return self.silence_threshold
+        return self._threshold
 
+    def get_speech_duration(self) -> float:
+        """Return total accumulated audio duration since last reset.
 
-def calibrate_silence_threshold(
-    device: str | int | None = None,
-    duration: float = 2.0,
-    sample_rate: int = 16000,
-) -> float:
-    """Calibrate silence threshold by measuring ambient noise.
+        Returns:
+            Duration in seconds.
+        """
+        return self._total_samples / self._sample_rate
 
-    Records a short sample of ambient noise and calculates an appropriate
-    silence threshold using multiple features.
+    def get_silence_duration(self) -> float:
+        """Not available with Silero VAD.
 
-    Args:
-        device: Audio device name or index.
-        duration: Duration to record for calibration (seconds).
-        sample_rate: Sample rate in Hz.
-
-    Returns:
-        Recommended silence threshold (RMS value).
-    """
-    import sounddevice as sd
-
-    debug(f"Calibrating silence threshold ({duration}s)...")
-
-    # Record ambient noise
-    audio = sd.rec(
-        int(duration * sample_rate),
-        samplerate=sample_rate,
-        channels=1,
-        dtype="float32",
-        device=device,
-    )
-    sd.wait()
-
-    # Calculate RMS of ambient noise
-    rms = float(np.sqrt(np.mean(audio**2)))
-
-    # Calculate ZCR of ambient noise
-    audio_flat = audio.flatten()
-    signs = np.sign(audio_flat)
-    zcr = float(np.sum(np.abs(np.diff(signs)) > 0) / (len(audio_flat) - 1))
-
-    # Set threshold slightly above ambient noise
-    threshold = rms * 2.0
-
-    debug(f"Ambient noise RMS: {rms:.4f}, ZCR: {zcr:.4f}")
-    debug(f"Recommended threshold: {threshold:.4f}")
-
-    return threshold
+        Returns:
+            Always returns 0.0.
+        """
+        return 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["asr2clip"]
-exclude = ["asr2clip/local_asr", "asr2clip/_vendor"]
+exclude = ["asr2clip/local_asr", "asr2clip/_vendor", "asr2clip/vad.py"]
 
 [tool.complexipy]
 paths = ["asr2clip"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,11 @@ dev = [
     "build>=1.2.2.post1",
     "twine>=6.1.0",
 ]
-local_asr = [
+vad = [
     "sherpa-onnx>=1.10.0",
+]
+local_asr = [
+    "asr2clip[vad]",
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.20.0",
     "python-multipart>=0.0.6",


### PR DESCRIPTION
## Summary

- Replace the unreliable numpy-based multi-feature VAD (RMS + ZCR + spectral band) with **Silero VAD** neural network model via sherpa-onnx
- Add new `[vad]` optional dependency group (`pip install asr2clip[vad]`), `[local_asr]` now depends on `[vad]`
- Rewrite `vad.py`: auto model download (~629KB), chunk buffering for Silero's 512-sample window, thread-safe `process_chunk()`/`reset()`
- Simplify CLI: remove `--adaptive`, `--calibrate`, `--no_adaptive`; `--silence_threshold` is now a probability (0.0-1.0)
- Decouple interval-mode silence check from VAD threshold in `daemon.py`

Net -264 lines (476 deleted, 212 added).

## Test plan

- [ ] `pip install -e .[vad]` installs sherpa-onnx
- [ ] First `asr2clip --vad` auto-downloads silero_vad.onnx to `~/.local/share/asr2clip/models/`
- [ ] Speech followed by silence triggers transcription
- [ ] `--silence_threshold 0.3` (sensitive) and `0.8` (less sensitive) behave as expected
- [ ] Without sherpa-onnx: `asr2clip --vad` shows clear install instructions
- [ ] Non-VAD modes (`asr2clip`, `asr2clip --interval 30`) work without sherpa-onnx
- [ ] `pip install -e .[local_asr]` pulls in sherpa-onnx via `[vad]`