### PR TITLE
chore: add pre-commit hooks and Makefile lint targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# See https://pre-commit.com for more information
+repos:
+  # ── Ruff: lint + format ──────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # ── Local hooks (ty, complexipy) ─────────────────────────────────
+  # These require dev dependencies on PATH.
+  # Activate your project virtualenv / conda env before committing.
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty (type check)
+        entry: ty check
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true
+
+      - id: complexipy
+        name: complexipy (complexity check)
+        entry: complexipy asr2clip/ -e _vendor
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to asr2clip
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-change`)
+3. Install dev dependencies: `pip install -e ".[dev]"`
+4. Set up pre-commit hooks: `pre-commit install`
+5. Make your changes
+6. Run `make check` (or let pre-commit catch issues on commit)
+7. Test that `asr2clip --help` and basic functionality still work
+8. Commit and push
+9. Open a Pull Request
+
+## Branch Naming
+
+Use descriptive prefixes:
+
+- `feature/xxx` — new functionality
+- `fix/xxx` — bug fix
+- `refactor/xxx` — code restructuring
+- `docs/xxx` — documentation updates
+- `test/xxx` — test additions or changes
+
+## Commit Messages
+
+Keep commit messages concise and focused on *why*, not *what*. One logical change per commit.
+
+## Pull Requests
+
+- Keep PRs focused — one feature or fix per PR
+- Include a brief description of what changed and why
+- Mention any breaking changes explicitly
+- Ensure `ruff check` passes before submitting
+
+## AI-Assisted Contributions
+
+Using AI tools (e.g. Claude, Cursor, Copilot) to assist with development is welcome. However:
+
+- **No AI co-author tags in commits.** Do not add `Co-authored-by` lines for AI tools in git commit messages. This keeps the git history clean and readable.
+- **Disclose in PR description.** If AI tools were used significantly in your contribution, add a brief note in the PR description (e.g. "AI was used to assist with implementation").
+- **You own the code.** Contributors are fully responsible for any AI-generated code they submit — review it, test it, understand it.
+
+## Code Style
+
+- Python code follows `ruff` defaults
+- Docstrings use Google style
+- Comments and docstrings in English
+- Type hints are encouraged
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [GNU AGPL v3](LICENSE).

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,38 @@
 PACKAGE_NAME := asr2clip
 DIST_DIR := dist
 BUILD_DIR := build
+SRC_DIR := asr2clip
 
 # Default target
 all: build
+
+# ── Code quality ──────────────────────────────────────────────────
+
+# Run all checks (mirrors CI)
+check: lint format-check typecheck complexity
+
+# Lint with ruff
+lint:
+	ruff check $(SRC_DIR)/
+
+# Auto-format with ruff
+format:
+	ruff check --fix $(SRC_DIR)/
+	ruff format $(SRC_DIR)/
+
+# Check formatting without modifying files
+format-check:
+	ruff format --check $(SRC_DIR)/
+
+# Type check with ty
+typecheck:
+	ty check
+
+# Cyclomatic complexity check
+complexity:
+	complexipy $(SRC_DIR)/ -e "_vendor"
+
+# ── Packaging ─────────────────────────────────────────────────────
 
 # Build the package
 build:
@@ -26,12 +55,22 @@ clean:
 	rm -rf $(BUILD_DIR) $(DIST_DIR) *.egg-info
 	@echo "Cleanup complete."
 
-# Help target
+# ── Help ──────────────────────────────────────────────────────────
+
 help:
 	@echo "Available targets:"
-	@echo "  build   - Build the pip package"
-	@echo "  push    - Push the package to PyPI"
-	@echo "  clean   - Clean up build and distribution files"
-	@echo "  help    - Show this help message"
+	@echo ""
+	@echo "  Code quality:"
+	@echo "    check        - Run all checks (lint + format-check + typecheck + complexity)"
+	@echo "    lint         - Lint with ruff"
+	@echo "    format       - Auto-fix lint issues and format code"
+	@echo "    format-check - Check formatting without modifying files"
+	@echo "    typecheck    - Type check with ty"
+	@echo "    complexity   - Cyclomatic complexity check with complexipy"
+	@echo ""
+	@echo "  Packaging:"
+	@echo "    build        - Build the pip package"
+	@echo "    push         - Push the package to PyPI"
+	@echo "    clean        - Clean up build and distribution files"
 
-.PHONY: all build push clean help
+.PHONY: all check lint format format-check typecheck complexity build push clean help

--- a/asr2clip/asr2clip.py
+++ b/asr2clip/asr2clip.py
@@ -352,36 +352,86 @@ def _validate_args(args: argparse.Namespace):
         args.silence_threshold = 0.5
 
 
+def _handle_serve(args: argparse.Namespace) -> None:
+    """Start the local ASR server.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    from .local_asr import check_deps
+
+    check_deps()
+    from .local_asr.app import run_server
+
+    run_server(
+        host=args.host,
+        port=args.port,
+        model_dir=args.model_dir,
+        num_threads=args.num_threads,
+    )
+
+
+def _handle_download_model(args: argparse.Namespace) -> None:
+    """Download the default ASR model.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    from .local_asr import check_deps
+
+    check_deps()
+    from .local_asr.model_registry import create_registry
+
+    registry = create_registry(model_dir=args.model_dir)
+    default_cfg = registry.get_default_model()
+    registry.download_model(default_cfg)
+
+
+def _handle_continuous(args: argparse.Namespace, config: dict, device) -> None:
+    """Run continuous recording mode (VAD or fixed interval).
+
+    Args:
+        args: Parsed CLI arguments.
+        config: Configuration dictionary.
+        device: Audio device name or index.
+    """
+    api_key, api_base_url, model_name, org_id = get_api_config(config)
+    if args.vad:
+        try:
+            __import__("sherpa_onnx")
+        except ImportError:
+            print(
+                "Error: VAD requires sherpa-onnx.\n"
+                "Install with: pip install asr2clip[vad]"
+            )
+            sys.exit(1)
+    interval = args.interval if args.interval is not None else 30.0
+    continuous_recording(
+        api_key=api_key,
+        api_base_url=api_base_url,
+        model_name=model_name,
+        org_id=org_id,
+        device=device,
+        interval=interval,
+        output_file=args.output,
+        vad_enabled=args.vad,
+        silence_threshold=args.silence_threshold,
+        silence_duration=args.silence_duration,
+    )
+
+
 def main():
     """Main entry point for asr2clip."""
     parser = _build_parser()
     args = parser.parse_args()
 
-    # Handle --serve (local ASR server) — before validation
+    # Handle --serve and --download-model before validation
     if args.serve:
-        from .local_asr import check_deps
-
-        check_deps()
-        from .local_asr.app import run_server
-
-        run_server(
-            host=args.host,
-            port=args.port,
-            model_dir=args.model_dir,
-            num_threads=args.num_threads,
-        )
+        _handle_serve(args)
         return
 
-    # Handle --download-model — before validation
     if args.download_model:
-        from .local_asr import check_deps
-
-        check_deps()
-        from .local_asr.model_registry import create_registry
-
-        registry = create_registry(model_dir=args.model_dir)
-        default_cfg = registry.get_default_model()
-        registry.download_model(default_cfg)
+        _handle_download_model(args)
         return
 
     _validate_args(args)
@@ -423,29 +473,7 @@ def main():
         return
 
     if args.vad or args.interval is not None:
-        api_key, api_base_url, model_name, org_id = get_api_config(config)
-        if args.vad:
-            try:
-                __import__("sherpa_onnx")
-            except ImportError:
-                print(
-                    "Error: VAD requires sherpa-onnx.\n"
-                    "Install with: pip install asr2clip[vad]"
-                )
-                sys.exit(1)
-        interval = args.interval if args.interval is not None else 30.0
-        continuous_recording(
-            api_key=api_key,
-            api_base_url=api_base_url,
-            model_name=model_name,
-            org_id=org_id,
-            device=device,
-            interval=interval,
-            output_file=args.output,
-            vad_enabled=args.vad,
-            silence_threshold=args.silence_threshold,
-            silence_duration=args.silence_duration,
-        )
+        _handle_continuous(args, config, device)
         return
 
     process_recording(config, device, args.output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ asr2clip-serve = "asr2clip.local_asr:cli_main"
 [project.optional-dependencies]
 dev = [
     "complexipy>=5.2.0",
+    "pre-commit>=4.0.0",
     "ruff>=0.15.0",
     "ty>=0.0.31",
     "build>=1.2.2.post1",


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with ruff (lint + format), ty (type check), and complexipy (complexity check) hooks
- Add `lint`, `format`, `format-check`, `typecheck`, `complexity`, and `check` targets to Makefile — `make check` mirrors CI
- Add `pre-commit` to dev dependencies
- Add `CONTRIBUTING.md` with setup steps and AI contribution policy
- Extract helpers from `main()` to fix pre-existing complexipy failure (complexity 16 → 11, limit is 15)

Hooks use `language: system` for ty and complexipy (no official pre-commit mirrors yet), so the project virtualenv / conda env must be activated when committing.

## Test plan

- [ ] `pre-commit run --all-files` passes
- [ ] `make check` passes
- [ ] CI passes (ruff, ty, complexipy)